### PR TITLE
Create Dockerfile for server.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+ARG ZOTERO_PDF2ZH_FROM_IMAGE
+FROM ${ZOTERO_PDF2ZH_FROM_IMAGE}
+
+ARG ZOTERO_PDF2ZH_SERVER_FILE_DOWNLOAD_URL
+
+WORKDIR /app
+
+# 如果国内环境打包取消注释，使用镜像
+# RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list.d/debian.sources && \
+#    sed -i 's/security.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list.d/debian.sources
+
+RUN apt-get update && \
+# 调试网络用工具
+#    apt-get -y install iproute2 curl vim iputils-ping procps net-tools traceroute dnsutils && \
+# 如果国内环境打包取消注释，使用镜像
+#    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple && \
+#    pip config set global.extra-index-url "https://pypi.tuna.tsinghua.edu.cn/simple" && \
+    uv pip install --system -U flask waitress pypdf
+
+ADD "${ZOTERO_PDF2ZH_SERVER_FILE_DOWNLOAD_URL}" /app/
+# fix bug in server.py for run in Linux
+RUN sed -i '/path = path\.replace/ s/ #//' /app/server.py
+
+EXPOSE 8888
+CMD ["python", "server.py", "8888"]


### PR DESCRIPTION
github/gitea workfow 添加，docker hub相关信息替换成自己的
```yaml
    env:
      ZOTERO_PDF2ZH_VERSION: 2.2.3
      PDF2ZH_VERSION: 1.9.4
```
```yaml
      - name: Set up Docker Buildx
        uses: https://github.com/docker/setup-buildx-action@v3
        with:
          driver-opts: |
            image=moby/buildkit:v0.18.2
      - name: Login to Docker Registry
        uses: https://github.com/docker/login-action@v3
        with:
          registry: hub.docker.com
          username: ${{ secrets.USERNAME }}
          password: ${{ secrets.PASSWORD }}
      - name: Build and push
        uses: https://github.com/docker/build-push-action@v6
        with:
          context: .
          push: true
          platforms: linux/amd64
          build-args: |
            ZOTERO_PDF2ZH_SERVER_FILE_DOWNLOAD_URL=https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/refs/tags/v${{ env.ZOTERO_PDF2ZH_VERSION}}/server.py
            ZOTERO_PDF2ZH_FROM_IMAGE=byaidu/pdf2zh:${{ env.PDF2ZH_VERSION}}
          tags: |
            hub.github.com/guaguastandup/zotero-pdf2zh:${{ env.ZOTERO_PDF2ZH_VERSION }}-pdf2zh-${{ env.PDF2ZH_VERSION}}
```
