### PR TITLE
feat: auto-delete files in translate/ directory after translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn.lock
 .DS_Store
 .env
 .scaffold
+config.json


### PR DESCRIPTION
## ✨ Feature: Auto-delete translated files after processing

This pull request adds a simple enhancement to `server.py`:
After translation is completed, all files in the `translate/` directory are automatically deleted.

### 📌 Motivation
When translating many files, the `translate/` folder can accumulate temporary files over time. Automatically cleaning up this folder after use helps avoid clutter and ensures the workspace stays clean.

### 🛠️ Changes
- Modified `server.py` to remove files in `translate/` after translation is done
- Updated `.gitignore` to reflect this behavior if needed

Let me know if any changes are needed. I'm happy to help improve the tool and would love to contribute more if there's interest.

GitHub ID: @liu-qingyuan