### PR TITLE
Add macOS Finder Right-click PDF Translation

### DIFF
--- a/automation/macos/translate_pdf_client.py
+++ b/automation/macos/translate_pdf_client.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+import os
+import sys
+import base64
+import json
+import time
+import requests
+import subprocess
+import shutil
+from pathlib import Path
+
+class PDFTranslatorClient:
+    def __init__(self, server_url="http://localhost:8888"):
+        self.server_url = server_url
+        self.project_path = Path(__file__).parent
+        self.conda_env = "zotero-pdf2zh"
+        
+    def send_notification(self, title, message):
+        """发送 macOS 通知"""
+        try:
+            if self._command_exists('terminal-notifier'):
+                cmd = [
+                    'terminal-notifier',
+                    '-title', title,
+                    '-message', message,
+                    '-group', 'pdf-translate-quickaction'
+                ]
+                subprocess.run(cmd, check=False, capture_output=True)
+            else:
+                cmd = ['osascript', '-e', f'display notification "{message}" with title "{title}"']
+                subprocess.run(cmd, check=False, capture_output=True)
+        except Exception as e:
+            print(f"通知发送失败: {e}")
+    
+    def _command_exists(self, command):
+        """检查命令是否存在"""
+        try:
+            subprocess.run(['which', command], check=True, capture_output=True)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+    
+    def is_server_running(self):
+        """检查翻译服务器是否运行"""
+        try:
+            response = requests.get(f"{self.server_url}/", timeout=2)
+            return response.status_code < 500
+        except:
+            return False
+    
+    def start_server(self):
+        """启动翻译服务器"""
+        self.send_notification("PDF 翻译", "正在启动翻译服务...")
+        
+        # 查找 Python 解释器
+        python_paths = [
+            f"/opt/anaconda3/envs/{self.conda_env}/bin/python",
+            f"/Users/{os.environ.get('USER')}/opt/anaconda3/envs/{self.conda_env}/bin/python",
+            f"/usr/local/anaconda3/envs/{self.conda_env}/bin/python"
+        ]
+        
+        python_exe = None
+        for path in python_paths:
+            if os.path.exists(path):
+                python_exe = path
+                break
+        
+        if not python_exe:
+            raise Exception("找不到 Python 环境，请检查 conda 环境配置")
+        
+        # 启动服务器
+        server_script = self.project_path / "server.py"
+        subprocess.Popen(
+            [python_exe, str(server_script), "8888"],
+            cwd=str(self.project_path),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
+        )
+        
+        # 等待服务器启动
+        for i in range(30):  # 最多等待30秒
+            time.sleep(1)
+            if self.is_server_running():
+                self.send_notification("PDF 翻译", "翻译服务已启动")
+                return True
+        
+        raise Exception("翻译服务启动失败")
+    
+    def translate_pdf(self, pdf_path):
+        """翻译 PDF 文件"""
+        pdf_path = Path(pdf_path)
+        
+        if not pdf_path.exists():
+            raise FileNotFoundError(f"文件不存在: {pdf_path}")
+        
+        if pdf_path.suffix.lower() != '.pdf':
+            raise ValueError("只支持 PDF 文件")
+        
+        # 确保服务器运行
+        if not self.is_server_running():
+            self.start_server()
+        
+        # 发送开始通知
+        self.send_notification(
+            "PDF 翻译开始",
+            f"正在翻译: {pdf_path.name}"
+        )
+        
+        # 读取文件并编码
+        with open(pdf_path, 'rb') as f:
+            file_content = base64.b64encode(f.read()).decode('utf-8')
+        
+        # 读取配置
+        config_path = self.project_path / "config.json"
+        config_data = {}
+        if config_path.exists():
+            with open(config_path, 'r', encoding='utf-8') as f:
+                config_data = json.load(f)
+        
+        # 准备请求数据
+        request_data = {
+            'fileName': pdf_path.name,
+            'fileContent': f'data:application/pdf;base64,{file_content}',
+            'service': config_data.get('translators', [{}])[0].get('name', 'deepseek'),
+            'engine': 'pdf2zh',
+            'threadNum': 4,
+            'outputPath': str(self.project_path / 'translated'),
+            'configPath': str(config_path),
+            'sourceLang': 'en',
+            'targetLang': 'zh'
+        }
+        
+        # 发送翻译请求
+        try:
+            response = requests.post(
+                f"{self.server_url}/translate",
+                json=request_data,
+                timeout=600  # 10分钟超时
+            )
+            
+            if response.status_code == 200:
+                # 查找生成的 dual PDF
+                translated_dir = self.project_path / 'translated'
+                base_name = pdf_path.stem
+                dual_pdf = translated_dir / f"{base_name}-dual.pdf"
+                
+                # 等待文件生成
+                for _ in range(10):
+                    if dual_pdf.exists():
+                        break
+                    time.sleep(0.5)
+                
+                if dual_pdf.exists():
+                    # 将文件复制到原位置
+                    target_path = pdf_path.parent / f"{base_name}-dual.pdf"
+                    shutil.copy2(dual_pdf, target_path)
+                    
+                    self.send_notification(
+                        "PDF 翻译完成",
+                        f"✅ 已生成: {target_path.name}"
+                    )
+                    
+                    # 在 Finder 中显示文件
+                    subprocess.run(['open', '-R', str(target_path)])
+                    
+                    return str(target_path)
+                else:
+                    raise Exception("翻译完成但未找到生成的文件")
+            else:
+                error_msg = response.json().get('message', '未知错误')
+                raise Exception(f"翻译失败: {error_msg}")
+                
+        except requests.exceptions.Timeout:
+            raise Exception("翻译超时，请检查文件大小")
+        except Exception as e:
+            raise Exception(f"翻译错误: {str(e)}")
+
+def main():
+    if len(sys.argv) < 2:
+        print("用法: python translate_pdf_client.py <pdf_file_path>")
+        sys.exit(1)
+    
+    pdf_path = sys.argv[1]
+    client = PDFTranslatorClient()
+    
+    try:
+        result = client.translate_pdf(pdf_path)
+        print(f"翻译成功: {result}")
+    except Exception as e:
+        error_msg = str(e)
+        print(f"错误: {error_msg}")
+        client.send_notification("PDF 翻译失败", f"❌ {error_msg}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/automation/macos/translate_pdf_quick_action.sh
+++ b/automation/macos/translate_pdf_quick_action.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+# PDF 翻译 Quick Action 包装脚本
+# 用于 macOS Automator Quick Action
+
+# 配置
+PROJECT_PATH="/Users/apple/Documents/zotero-pdf2zh"
+CONDA_ENV_NAME="zotero-pdf2zh"
+# 使用用户库日志目录，避免权限问题
+LOG_FILE="$HOME/Library/Logs/PDFTranslateQuickAction.log"
+
+# 创建日志目录
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+
+# 日志函数
+log() {
+    # 输出到标准错误（在 Automator 中可见）
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >&2
+    # 尝试写入日志文件，如果失败则忽略
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+# 开始记录
+log "=== 开始 PDF 翻译 Quick Action ==="
+log "接收到的参数: $@"
+
+# 检查参数
+if [ $# -eq 0 ]; then
+    log "错误: 没有提供 PDF 文件路径"
+    osascript -e 'display dialog "请选择一个 PDF 文件" buttons {"确定"} default button 1 with icon stop'
+    exit 1
+fi
+
+# 获取 PDF 文件路径
+PDF_PATH="$1"
+log "PDF 文件路径: $PDF_PATH"
+
+# 检查文件是否存在
+if [ ! -f "$PDF_PATH" ]; then
+    log "错误: 文件不存在 - $PDF_PATH"
+    osascript -e 'display dialog "文件不存在" buttons {"确定"} default button 1 with icon stop'
+    exit 1
+fi
+
+# 检查是否为 PDF 文件
+if [[ ! "$PDF_PATH" =~ \.pdf$ ]] && [[ ! "$PDF_PATH" =~ \.PDF$ ]]; then
+    log "错误: 不是 PDF 文件 - $PDF_PATH"
+    osascript -e 'display dialog "请选择 PDF 文件" buttons {"确定"} default button 1 with icon stop'
+    exit 1
+fi
+
+# 尝试查找 Python 解释器
+PYTHON_PATHS=(
+    "/opt/anaconda3/envs/$CONDA_ENV_NAME/bin/python"
+    "/Users/$USER/opt/anaconda3/envs/$CONDA_ENV_NAME/bin/python"
+    "/usr/local/anaconda3/envs/$CONDA_ENV_NAME/bin/python"
+    "$HOME/miniconda3/envs/$CONDA_ENV_NAME/bin/python"
+    "$HOME/anaconda3/envs/$CONDA_ENV_NAME/bin/python"
+)
+
+PYTHON_EXE=""
+for path in "${PYTHON_PATHS[@]}"; do
+    if [ -f "$path" ]; then
+        PYTHON_EXE="$path"
+        log "找到 Python: $PYTHON_EXE"
+        break
+    fi
+done
+
+# 如果没找到，尝试使用 conda
+if [ -z "$PYTHON_EXE" ]; then
+    if command -v conda >/dev/null 2>&1; then
+        log "尝试通过 conda 查找环境..."
+        # 尝试激活 conda
+        if [ -f "$HOME/opt/anaconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/opt/anaconda3/etc/profile.d/conda.sh"
+        elif [ -f "/opt/anaconda3/etc/profile.d/conda.sh" ]; then
+            source "/opt/anaconda3/etc/profile.d/conda.sh"
+        elif [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/miniconda3/etc/profile.d/conda.sh"
+        fi
+        
+        # 激活环境
+        conda activate "$CONDA_ENV_NAME" 2>/dev/null
+        if [ $? -eq 0 ]; then
+            PYTHON_EXE="python"
+            log "成功激活 conda 环境"
+        fi
+    fi
+fi
+
+# 最后检查
+if [ -z "$PYTHON_EXE" ] || ! command -v "$PYTHON_EXE" >/dev/null 2>&1; then
+    log "错误: 找不到 Python 环境"
+    osascript -e 'display dialog "找不到 Python 环境，请检查 conda 环境配置" buttons {"确定"} default button 1 with icon stop'
+    exit 1
+fi
+
+# 检查客户端脚本是否存在
+CLIENT_SCRIPT="$PROJECT_PATH/translate_pdf_client.py"
+if [ ! -f "$CLIENT_SCRIPT" ]; then
+    log "错误: 找不到客户端脚本 - $CLIENT_SCRIPT"
+    osascript -e 'display dialog "翻译客户端脚本不存在" buttons {"确定"} default button 1 with icon stop'
+    exit 1
+fi
+
+# 执行翻译
+log "开始执行翻译..."
+log "命令: $PYTHON_EXE $CLIENT_SCRIPT \"$PDF_PATH\""
+
+# 设置环境变量
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+export LANG="en_US.UTF-8"
+export LC_ALL="en_US.UTF-8"
+
+# 执行 Python 脚本
+cd "$PROJECT_PATH"
+OUTPUT=$("$PYTHON_EXE" "$CLIENT_SCRIPT" "$PDF_PATH" 2>&1)
+EXIT_CODE=$?
+
+# 记录输出
+log "Python 脚本输出: $OUTPUT"
+log "退出码: $EXIT_CODE"
+
+# 检查执行结果
+if [ $EXIT_CODE -eq 0 ]; then
+    log "翻译成功完成"
+else
+    log "翻译过程出错"
+    # 从输出中提取错误信息
+    ERROR_MSG=$(echo "$OUTPUT" | grep -E "(错误|Error|Exception)" | head -n 1)
+    if [ -z "$ERROR_MSG" ]; then
+        ERROR_MSG="翻译失败，请查看日志文件: ~/Library/Logs/PDFTranslateQuickAction.log"
+    fi
+    osascript -e "display dialog \"$ERROR_MSG\" buttons {\"确定\"} default button 1 with icon stop"
+fi
+
+log "=== PDF 翻译 Quick Action 结束 ==="
+log ""
+
+exit $EXIT_CODE

--- a/automation/macos/右键菜单配置教程.md
+++ b/automation/macos/右键菜单配置教程.md
@@ -1,0 +1,193 @@
+# macOS 右键菜单 PDF 翻译功能配置教程
+
+本教程将指导您配置 macOS 右键菜单，实现在任意位置对 PDF 文件进行快速翻译。
+
+## 功能效果
+- 在 Finder 中右键点击任意 PDF 文件
+- 选择"翻译 PDF 为双栏"
+- 自动在原文件位置生成翻译后的 `-dual.pdf` 文件
+- 全程显示进度通知
+
+## 前置要求
+
+1. 已完成 Zotero PDF 翻译服务的基础配置
+2. 已安装必要的 Python 依赖包：
+   ```bash
+   conda activate zotero-pdf2zh
+   pip install requests
+   ```
+
+## 配置步骤
+
+### 步骤 1：验证脚本安装
+
+确认以下文件已正确创建：
+- `/Users/apple/Documents/zotero-pdf2zh/translate_pdf_client.py`
+- `/Users/apple/Scripts/translate_pdf_quick_action.sh`
+
+运行测试脚本验证功能：
+```bash
+cd /Users/apple/Documents/zotero-pdf2zh
+python test_quick_action.py
+```
+
+### 步骤 2：创建 Automator Quick Action
+
+1. **打开 Automator**
+   - 在 Spotlight 中搜索 "Automator" 并打开
+   - 或者：应用程序 → Automator
+
+2. **创建新的 Quick Action**
+   - 选择"新建文稿"
+   - 选择"快速操作"（Quick Action）
+   - 点击"选取"
+
+3. **配置工作流接收设置**
+   - 在顶部设置：
+     - 工作流程接收当前：**PDF 文件**
+     - 位于：**Finder.app**
+     - 图像：选择一个合适的图标（可选）
+     - 颜色：选择喜欢的颜色（可选）
+
+4. **添加运行 Shell 脚本动作**
+   - 在左侧动作库中搜索"运行 Shell 脚本"
+   - 双击或拖拽到右侧工作区
+
+5. **配置 Shell 脚本**
+   - Shell：**/bin/bash**
+   - 传递输入：**作为自变量**
+   - 脚本内容：
+   ```bash
+   /Users/apple/Scripts/translate_pdf_quick_action.sh "$@"
+   ```
+
+6. **保存 Quick Action**
+   - 按 ⌘+S 保存
+   - 名称：**翻译 PDF 为双栏**
+   - 位置：默认（iCloud Drive 或本地）
+
+### 步骤 3：授予必要权限
+
+首次使用时，macOS 可能要求授予以下权限：
+
+1. **Finder 访问权限**
+   - 系统偏好设置 → 安全性与隐私 → 隐私
+   - 选择"自动化"
+   - 确保 Automator 和 Finder 已勾选
+
+2. **通知权限**
+   - 系统偏好设置 → 通知与专注模式
+   - 找到 Terminal 或 terminal-notifier
+   - 允许通知
+
+### 步骤 4：使用方法
+
+1. 在 Finder 中找到要翻译的 PDF 文件
+2. 右键点击文件
+3. 选择"快速操作" → "翻译 PDF 为双栏"
+4. 等待翻译完成（会显示通知）
+5. 翻译完成后，会在同目录生成 `-dual.pdf` 文件
+
+## 故障排除
+
+### 问题 1：右键菜单中没有出现选项
+- 确认 Quick Action 已正确保存
+- 重启 Finder：按住 Option 键，右键点击 Finder 图标，选择"重新开启"
+- 检查系统偏好设置 → 扩展 → Finder，确保已启用
+
+### 问题 2：点击后没有反应
+- 查看日志文件：`~/Library/Logs/PDFTranslateQuickAction.log`
+  ```bash
+  tail -f ~/Library/Logs/PDFTranslateQuickAction.log
+  ```
+- 确认 Shell 脚本有执行权限：
+  ```bash
+  chmod +x /Users/apple/Scripts/translate_pdf_quick_action.sh
+  ```
+
+### 问题 5：权限错误 (Operation not permitted)
+如果遇到权限错误，日志文件已更改到用户库目录：
+- 新日志位置：`~/Library/Logs/PDFTranslateQuickAction.log`
+- 这个位置对 Automator 始终可写
+
+### 问题 3：提示找不到 Python 环境
+- 确认 conda 环境已创建：
+  ```bash
+  conda env list | grep zotero-pdf2zh
+  ```
+- 修改 Shell 脚本中的 Python 路径
+
+### 问题 4：翻译服务未启动
+- 脚本会自动尝试启动服务
+- 如果失败，手动启动：
+  ```bash
+  cd /Users/apple/Documents/zotero-pdf2zh
+  conda activate zotero-pdf2zh
+  python server.py
+  ```
+
+## 高级配置
+
+### 自定义翻译参数
+
+编辑 `translate_pdf_client.py`，修改默认翻译参数：
+```python
+request_data = {
+    # ... 其他参数
+    'service': 'deepseek',  # 更改翻译服务
+    'threadNum': 8,         # 增加线程数
+    'sourceLang': 'en',     # 源语言
+    'targetLang': 'zh'      # 目标语言
+}
+```
+
+### 添加更多输出格式
+
+在 Quick Action 中可以添加参数，支持不同的输出格式：
+- `-mono.pdf`：单栏翻译
+- `-dual.pdf`：双栏对照（默认）
+- `-compare.pdf`：左右对比
+- `-single-compare.pdf`：单页对比
+
+### 批量处理
+
+创建一个新的 Quick Action，支持选择多个 PDF 文件同时翻译：
+```bash
+for pdf in "$@"; do
+    /Users/apple/Scripts/translate_pdf_quick_action.sh "$pdf" &
+done
+wait
+```
+
+## 注意事项
+
+1. **性能考虑**
+   - 大文件翻译可能需要较长时间
+   - 建议同时翻译的文件不超过 3 个
+
+2. **磁盘空间**
+   - 翻译后的文件会保存在原位置
+   - 临时文件保存在 `translated/` 目录
+
+3. **API 限制**
+   - 注意翻译服务的 API 调用限制
+   - DeepSeek 等服务可能有并发限制
+
+## 卸载方法
+
+如需移除此功能：
+
+1. 删除 Quick Action：
+   - 打开 Finder
+   - 前往 `~/Library/Services/`
+   - 删除"翻译 PDF 为双栏.workflow"
+
+2. 删除相关脚本：
+   ```bash
+   rm /Users/apple/Scripts/translate_pdf_quick_action.sh
+   rm /Users/apple/Documents/zotero-pdf2zh/translate_pdf_client.py
+   ```
+
+---
+
+配置完成后，您就可以在任意位置快速翻译 PDF 文件了！如有问题，请查看日志文件或联系技术支持。


### PR DESCRIPTION
  Adds a macOS context menu option to translate PDF files directly from Finder using the existing translation service.

  ### What's Added
  - Right-click any PDF → Quick Actions → Translate to dual-column format
  - Auto-starts translation server if not running
  - Shows progress notifications
  - Creates translated file in same directory

  ### Files
  - `translate_pdf_client.py` - Python translation client
  - `translate_pdf_quick_action.sh` - Shell script for Automator
  - `README.md` - Setup instructions
  - `右键菜单配置教程.md` - Chinese tutorial

  ### Usage
  1. Right-click PDF file in Finder
  2. Select Quick Actions → "翻译 PDF 为双栏"
  3. Wait for translation complete notification
  4. Find `-dual.pdf` file in same folder

  Works with existing Zotero automation system.