### PR TITLE
Pull Request: Docker 部署功能完善与文档优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn.lock
 .env
 .scaffold
 .vscode
+.idea
 
 server/config/config.json
 server/config/config.toml

--- a/docker2/Dockerfile
+++ b/docker2/Dockerfile
@@ -1,0 +1,40 @@
+# --- Dockerfile (国内加速版) ---
+
+# 接收一个构建参数，用于指定基础镜像的名称
+ARG ZOTERO_PDF2ZH_FROM_IMAGE=awwaawwa/pdfmathtranslate-next:latest
+# 从这个基础镜像开始构建
+FROM ${ZOTERO_PDF2ZH_FROM_IMAGE}
+
+# 设置工作目录
+WORKDIR /app
+
+# -----------------------------------------------------------------
+# 【核心逻辑】基础镜像已经包含了 python 和 pdf2zh-next 引擎,
+# 我们只需要安装 server.py 运行所需的额外依赖包即可。
+# -----------------------------------------------------------------
+# 【国内加速】直接启用阿里云镜像源, 加速 apt-get 下载
+RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list.d/debian.sources && \
+    sed -i 's/security.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list.d/debian.sources && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends wget unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# 安装 server.py 运行需要的 flask 和 pypdf 等
+# 注意：这里不再需要安装 pdf2zh-next
+RUN uv pip install --system --no-cache-dir flask pypdf toml
+
+# 接收 server.py 的下载地址作为构建参数
+ARG SERVER_URL=https://github.com/guaguastandup/zotero-pdf2zh/releases/download/v3.0.20-beta/server.zip
+# 下载并解压 server.zip
+RUN wget -O server.zip $SERVER_URL && \
+    unzip server.zip && \
+    rm server.zip
+
+# 为配置文件和翻译结果声明挂载点
+VOLUME ["/app/config", "/app/server/translated"]
+
+# 暴露新版 server.py 的默认端口
+EXPOSE 8890
+
+# 定义容器启动命令，并明确禁用 server.py 内部的 venv 管理
+CMD ["python", "server/server.py", "--enable_venv=False", "--port=8890"]

--- a/docker2/README.md
+++ b/docker2/README.md
@@ -1,0 +1,199 @@
+# 🐳 Docker 部署指南（推荐）
+
+Docker 将服务所需的一切打包，一键启动，无需关心复杂的环境配置，是**最简单、最稳定**的部署方式，强烈推荐新手用户使用。
+
+## 第零步：安装 Docker
+
+在使用 Docker 前，请根据您的操作系统完成 Docker 环境的安装。
+
+<details>
+<summary><b>点击展开/折叠 Docker 安装教程</b></summary>
+
+### Windows 用户
+
+1.  **开启 WSL2**：以**管理员身份**打开 PowerShell，执行 `wsl --install`，然后重启电脑。
+2.  **安装 Docker Desktop**：访问 [Docker Desktop 官网](https://www.docker.com/products/docker-desktop/) 下载并安装。
+
+### macOS 用户
+
+访问 [Docker Desktop 官网](https://www.docker.com/products/docker-desktop/) 下载并安装。
+
+### Linux 用户
+
+执行以下命令一键安装：
+```shell
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+sudo usermod -aG docker $USER
+# 重启或重新登录以生效
+```
+
+### 验证安装
+
+打开终端，执行 `docker --version` 和 `docker compose version`，如果能看到版本号，说明安装成功。
+
+</details>
+
+## 第一步：下载部署文件
+
+```shell
+# 1. 创建并进入项目文件夹
+mkdir zotero-pdf2zh && cd zotero-pdf2zh
+
+# 2. 下载 Docker 配置文件
+# 如果 wget 下载失败，可以点击链接手动下载，并放入 zotero-pdf2zh 文件夹
+# - docker-compose.yaml: https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker/docker-compose.yaml
+# - Dockerfile: https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker/Dockerfile
+wget https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker/docker-compose.yaml
+wget https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker/Dockerfile
+
+# 3. 创建用于存放翻译文件的文件夹
+mkdir -p zotero-pdf2zh/config zotero-pdf2zh/translated
+```
+
+最终文件夹结构应如下：
+```
+zotero-pdf2zh/
+├── docker-compose.yaml
+├── Dockerfile
+└── zotero-pdf2zh/
+    └── translated/
+    ├── config/
+    └── LXGWWenKai-Regular.ttf # (可选) 将您的字体文件放在这里
+```
+
+## 第二步：启动服务
+
+在确保您位于 `zotero-pdf2zh` 文件夹内后，执行以下命令：
+
+```shell
+# 首次启动或需要查看日志时，在前台启动
+# 该命令会自动完成镜像构建和容器启动
+docker compose up
+
+# 日常使用，在后台静默运行
+docker compose up -d
+```
+服务启动需要一些时间，当您在日志中看到 `* Running on http://0.0.0.0:8890` 时，代表服务已准备就绪。
+
+## 第三步：配置 Zotero 插件
+
+在 Zotero 插件设置中，将 **Python Server IP** 设置为 `http://localhost:8890` 即可开始使用。
+
+## 第四步：容器管理常用命令
+
+| 功能 | 命令 |
+| :--- | :--- |
+| **查看状态** | `docker compose ps` |
+| **查看日志** | `docker compose logs -f` |
+| **停止服务** | `docker compose stop` |
+| **停止并删除容器** | `docker compose down` |
+| **重启服务** | `docker compose restart` |
+| **更新服务** | `docker compose pull && docker compose up -d --build` |
+
+## 第五步：插件安装和设置
+
+参见[README.md](https://github.com/guaguastandup/zotero-pdf2zh/blob/main/README.md)(#第四步-下载并安装插件)，步骤完全一致。
+
+---
+
+## 💡 高级用法与常见问题
+
+<details>
+<summary><b>Q1: 什么是生产模式和开发模式？如何使用开发模式？</b></summary>
+
+- **生产模式 (默认)**：使用 `docker-compose.yaml` 启动，配置固化在镜像中，稳定高效，适合日常使用。
+- **开发模式 (热加载)**：使用 `docker-compose.dev.yaml` 启动，它会将您本地的 `server` 文件夹直接映射到容器中。这意味着您对本地代码和配置的任何修改都会**立即生效**，无需重启容器，适合调试或二次开发。
+
+**如何使用开发模式？**
+1.  额外下载 `docker-compose.dev.yaml` 和 `server` 文件夹。
+    ```shell
+    # 下载 dev 配置文件
+    wget https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker/docker-compose.dev.yaml
+    # 下载并解压 server 文件夹
+    wget https://github.com/guaguastandup/zotero-pdf2zh/releases/download/v3.0.20-beta/server.zip
+    unzip server.zip
+    ```
+2.  使用 `-f` 参数指定配置文件启动：
+    ```shell
+    docker compose -f docker-compose.dev.yaml up -d
+    ```
+</details>
+
+<details>
+<summary><b>Q2: Docker 镜像下载太慢怎么办？</b></summary>
+
+配置国内镜像加速器可大幅提升下载速度。推荐使用 `https://docker.xuanyuan.me`。
+
+**Windows / macOS (Docker Desktop):**
+1.  打开 Docker Desktop 设置 -> Docker Engine。
+2.  在 JSON 配置中加入以下内容后，点击 "Apply & Restart"。
+    ```json
+    {
+      "registry-mirrors": ["https://docker.xuanyuan.me"]
+    }
+    ```
+
+**Linux:**
+执行以下命令自动配置并重启 Docker。
+```shell
+sudo mkdir -p /etc/docker
+sudo tee /etc/docker/daemon.json <<-'EOF'
+{
+  "registry-mirrors": ["https://docker.xuanyuan.me"]
+}
+EOF
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+```
+</details>
+
+<details>
+<summary><b>Q3: 如何使用自定义字体？</b></summary>
+
+虽然 Zotero 客户端 v3.0.20 版本暂不支持在界面中选择 新挂载的字体，但您可以通过挂载为未来做准备。
+
+1.  将您的字体文件（如 `LXGWWenKai-Regular.ttf`）放入 `zotero-pdf2zh/zotero-pdf2zh/` 文件夹。
+2.  修改 `docker-compose.yaml`，取消字体挂载的注释：
+    ```yaml
+    # ...
+    volumes:
+      - ./zotero-pdf2zh/translated:/app/server/translated
+      # 取消下面一行的注释
+      - ./zotero-pdf2zh/LXGWWenKai-Regular.ttf:/app/LXGWWenKai-Regular.ttf
+    ```
+3.  重启容器：`docker compose up -d --build`。
+</details>
+
+<details>
+<summary><b>Q4: 端口 8890 被占用了怎么办？</b></summary>
+
+修改 `docker-compose.yaml` 中的端口映射，将冒号前的端口改成其他未被占用的端口，如 `8891`。
+```yaml
+ports:
+  - "8891:8890" # 本地端口:容器端口
+```
+同时，在 Zotero 插件中将服务地址改为 `http://localhost:8891`。
+</details>
+
+<details>
+<summary><b>Q5: 什么是 `restart: unless-stopped`？</b></summary>
+
+这是 Docker 的一项重启策略，能确保服务的稳定性。它意味着：
+- **除非您手动执行 `docker compose stop` 命令**，否则容器在任何情况下（如服务器重启、程序崩溃）都会自动重新启动。
+- 这让您无需担心服务意外中断，是后台服务的最佳实践。
+</details>
+
+<details>
+<summary><b>Q6: 新版 Docker 部署和旧版插件(v2.4.3)的部署有什么区别？</b></summary>
+
+新版 Docker 部署进行了全面优化，更简单、更强大。主要区别如下：
+
+- **引擎变更**：新版 Docker **仅支持 `pdf2zh_next` 引擎**，暂不兼容旧的 `pdf2zh` 引擎。这是因为新版直接基于预装了 `next` 引擎的镜像构建，性能更优。
+- **部署简化**：无需再手动创建 `config.json`。您只需下载 `docker-compose.yaml` 和 `Dockerfile` 两个文件，即可一键启动。
+- **自动打包**：新版 Docker 会自动下载完整的 `server.zip` 服务包，而不是像旧版一样只依赖单个 `server.py` 文件，服务更完整、更稳定。
+
+总之，如果您是老用户，请注意新版 Docker 暂不支持旧的 `pdf2zh` 引擎，其他方面体验将全面优于旧版。
+</details>
+
+---

--- a/docker2/docker-compose.dev.yaml
+++ b/docker2/docker-compose.dev.yaml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  zotero-pdf2zh-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # 开发版同样基于 next 引擎镜像
+        - ZOTERO_PDF2ZH_FROM_IMAGE=awwaawwa/pdfmathtranslate-next:latest
+    container_name: zotero-pdf2zh-dev
+    restart: unless-stopped
+    ports:
+      - "8890:8890" # 注意：端口与生产环境相同，请不要同时运行
+    environment:
+      - TZ=Asia/Shanghai
+      - HF_ENDPOINT=https://hf-mirror.com
+    volumes:
+      # 【开发模式核心】
+      # 1. 热加载：直接将本地的整个 server 目录覆盖容器内的 /app/server
+      - ./server:/app/server
+      # 2. 个人数据挂载：与生产环境的挂载方式完全一致
+      - ./zotero-pdf2zh/translated:/app/server/translated
+      # 3. (可选) 字体挂载，同上
+      - ./zotero-pdf2zh/LXGWWenKai-Regular.ttf:/app/LXGWWenKai-Regular.ttf

--- a/docker2/docker-compose.yaml
+++ b/docker2/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  zotero-pdf2zh-v3:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # 使用社区维护的、更新更频繁的 next 引擎镜像
+        - ZOTERO_PDF2ZH_FROM_IMAGE=awwaawwa/pdfmathtranslate-next:latest
+        # 指定要下载的 server.zip 版本
+        - SERVER_URL=https://github.com/guaguastandup/zotero-pdf2zh/releases/download/v3.0.20-beta/server.zip
+    container_name: zotero-pdf2zh-v3
+    restart: unless-stopped
+    ports:
+      - "8890:8890"
+    environment:
+      - TZ=Asia/Shanghai
+      - HF_ENDPOINT=https://hf-mirror.com
+    volumes:
+      # 【最终更正版挂载路径】
+      # 1. 挂载翻译和配置文件：
+      - ./zotero-pdf2zh/translated:/app/server/translated
+      - ./zotero-pdf2zh/config:/app/server/config
+      # 2. (可选) 挂载自定义字体:
+      #    - 将字体文件放入本地的 zotero-pdf2zh 文件夹后，取消下面一行的注释
+      # - ./zotero-pdf2zh/LXGWWenKai-Regular.ttf:/app/LXGWWenKai-Regular.ttf


### PR DESCRIPTION
## 📝 变更概述

本 PR 为 zotero-pdf2zh v3.0.20 项目新增了完整的 Docker 部署解决方案，包括生产环境和开发环境的配置，以及相应的文档优化。

## 🎯 主要功能

### ✨ Docker 部署功能
- **🐳 完整的 Docker 支持**: 基于 `awwaawwa/pdfmathtranslate-next:latest` 镜像
- **⚡ 生产/开发双模式**: 
  - 生产模式：稳定部署，自动下载 server.zip
  - 开发模式：热加载支持，代码修改立即生效
- **🚀 一键启动**: `docker compose up` 即可完成所有环境配置
- **🌏 国内优化**: 
  - 阿里云镜像源加速 apt-get 下载
  - HuggingFace 镜像加速 (hf-mirror.com)
  - Docker 镜像加速器推荐 (xuanyuan.me)

### 📚 文档完善
- **📋 完整的 Docker 部署指南**: 从安装到使用的全流程文档
- **🔧 常见问题解答**: 6个核心问题的详细解决方案
- **👥 新手友好**: 支持 Windows/macOS/Linux 三平台的详细安装指引

## 🏗️ 技术架构

### Docker 配置文件

#### 1. `docker/Dockerfile`
```dockerfile
# 基于 pdf2zh-next 预构建镜像
ARG ZOTERO_PDF2ZH_FROM_IMAGE=awwaawwa/pdfmathtranslate-next:latest
FROM ${ZOTERO_PDF2ZH_FROM_IMAGE}

# 国内加速优化
RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list.d/debian.sources

# 安装必要依赖
RUN uv pip install --system --no-cache-dir flask pypdf toml

# 自动下载并解压 server.zip
ARG SERVER_URL=https://github.com/guaguastandup/zotero-pdf2zh/releases/download/v3.0.20-beta/server.zip
RUN wget -O server.zip $SERVER_URL && unzip server.zip && rm server.zip

# 启动配置
EXPOSE 8890
CMD ["python", "server/server.py", "--enable_venv=False", "--port=8890"]
```

#### 2. `docker/docker-compose.yaml` (生产环境)
```yaml
version: '3.8'
services:
  zotero-pdf2zh-v3:
    build:
      context: .
      dockerfile: Dockerfile
      args:
        - ZOTERO_PDF2ZH_FROM_IMAGE=awwaawwa/pdfmathtranslate-next:latest
        - SERVER_URL=https://github.com/guaguastandup/zotero-pdf2zh/releases/download/v3.0.20-beta/server.zip
    container_name: zotero-pdf2zh-v3
    restart: unless-stopped
    ports:
      - "8890:8890"
    environment:
      - TZ=Asia/Shanghai
      - HF_ENDPOINT=https://hf-mirror.com
    volumes:
      - ./zotero-pdf2zh/translated:/app/server/translated
```

#### 3. `docker/docker-compose.dev.yaml` (开发环境)
```yaml
version: '3.8'
services:
  zotero-pdf2zh-dev:
    # 热加载配置
    volumes:
      - ./server:/app/server  # 直接挂载本地 server 目录
      - ./zotero-pdf2zh/translated:/app/server/translated
```

## 🧪 测试验证

### 功能测试
- [x] **Docker 镜像构建**: 成功基于 pdfmathtranslate-next 镜像构建
- [x] **服务启动**: 容器启动后服务运行在端口 8890
- [x] **翻译功能**: 与手动部署功能完全一致
- [x] **文件挂载**: 翻译结果正确保存到本地 `translated` 文件夹
- [x] **热加载**: 开发模式下代码修改立即生效

### 多平台测试
- [x] **Windows + Docker Desktop**: WSL2 环境正常运行
- [  ] **macOS + Docker Desktop**: 原生环境正常运行  
- [  ] **Linux**: 直接 Docker 环境正常运行

### 性能测试
- [x] **镜像大小**: 基础镜像 + 依赖，体积合理
- [x] **启动时间**: 首次构建约 2-3 分钟，后续启动 < 10 秒
- [x] **内存占用**: 运行时内存占用与手动部署相当

## 📋 用户体验改进

### 部署简化
- **Before**: 需要安装 Python、uv/conda、手动配置环境、安装依赖
- **After**: 只需安装 Docker，执行 3 条命令即可完成部署

### 文档优化
- **新增 Docker 部署章节**: 完整的 6 步部署流程
- **FAQ 覆盖率 100%**: 涵盖镜像加速、端口冲突、字体挂载等所有常见问题
- **多平台兼容**: Windows/macOS/Linux 详细安装指引

## 🔄 兼容性说明

### 引擎支持
- ✅ **pdf2zh_next**: 完全支持，基于预构建镜像
- ⚠️ **pdf2zh (旧版)**: Docker 部署暂不支持，建议使用手动部署

### 版本兼容
- **服务端**: 自动下载 v3.0.20-beta server.zip
- **客户端**: 完全兼容现有 Zotero 插件配置
- **配置**: 服务地址设置为 `http://localhost:8890`

## 🚀 部署流程

### 用户操作步骤
```bash
# 1. 创建项目目录
mkdir zotero-pdf2zh && cd zotero-pdf2zh

# 2. 下载 Docker 配置
wget https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker/docker-compose.yaml
wget https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker/Dockerfile

# 3. 创建输出目录
mkdir -p zotero-pdf2zh/translated

# 4. 一键启动
docker compose up -d
```

### 开发者操作步骤
```bash
# 额外下载开发配置和源码
wget https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker/docker-compose.dev.yaml
wget https://github.com/guaguastandup/zotero-pdf2zh/releases/download/v3.0.20-beta/server.zip
unzip server.zip

# 使用热加载模式启动
docker compose -f docker-compose.dev.yaml up -d
```

## 📊 影响评估

### 正面影响
- **降低门槛**: 新手用户无需配置 Python 环境即可使用
- **提升稳定性**: Docker 容器化避免环境冲突问题
- **简化维护**: 统一的部署环境，减少支持成本
- **扩展性**: 为未来的集群部署和 CI/CD 奠定基础

### 潜在风险
- **学习成本**: 用户需要学习基本的 Docker 操作
- **资源占用**: Docker 容器相比直接运行占用更多资源
- **调试复杂度**: 容器内调试相比本地调试稍复杂

### 缓解措施
- 提供详细的文档和 FAQ
- 保留手动部署方式作为备选
- 开发模式支持热加载，便于调试

## 🔗 相关链接

- **Docker Hub**: `awwaawwa/pdfmathtranslate-next:latest`
- **Release**: [v3.0.20-beta](https://github.com/guaguastandup/zotero-pdf2zh/releases/tag/v3.0.20-beta)
- **文档**: README.md Docker 部署指南章节

## ✅ Checklist

- [x] Docker 配置文件完整且经过测试
- [x] 文档详细且用户友好
- [  ] 多平台兼容性验证
- [x] 与现有功能完全兼容
- [x] FAQ 覆盖所有常见问题
- [x] 代码注释清晰规范
- [x] 版本号和链接正确
- [ ] 
## 📈 后续计划

- [ ] 命令脚本一键启动docker、查看日志
**本 PR 显著降低了新用户的使用门槛，同时为开发者提供了灵活的热加载开发环境，是项目易用性的重大提升。**