### PR TITLE
Update to Zotero 8

### DIFF
--- a/plugin/addon/manifest.json
+++ b/plugin/addon/manifest.json
@@ -14,7 +14,7 @@
             "id": "__addonID__",
             "update_url": "__updateURL__",
             "strict_min_version": "6.999",
-            "strict_max_version": "7.*"
+            "strict_max_version": "8.*"
         }
     }
 }

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -9,10 +9,11 @@
             "version": "3.0.32",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "zotero-plugin-toolkit": "^4.1.2"
+                "zotero-plugin-toolkit": "^5.1.0-beta.10"
             },
             "devDependencies": {
                 "@eslint/js": "^9.22.0",
+                "@napi-rs/canvas": "^0.1.80",
                 "@types/node": "^22.13.10",
                 "axios": "^1.8.2",
                 "eslint": "^9.22.0",
@@ -22,7 +23,7 @@
                 "typescript": "^5.8.2",
                 "typescript-eslint": "^8.26.0",
                 "zotero-plugin-scaffold": "^0.3.2",
-                "zotero-types": "^3.1.7"
+                "zotero-types": "^4.1.0-beta.4"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -451,10 +452,11 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-            "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+            "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^3.4.3"
             },
@@ -490,9 +492,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-            "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+            "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -505,19 +507,22 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.1.0.tgz",
-            "integrity": "sha512-kLrdPDJE1ckPo94kmPPf9Hfd0DU0Jw6oKYrhe+pwSC0iTUInmTa+w6fw8sGgcfkFJGNdWOUeOaDM4quW4a7OkA==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
+            "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.16.0"
+            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-            "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+            "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -528,9 +533,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
-            "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+            "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -552,13 +557,16 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.22.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.22.0.tgz",
-            "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
+            "version": "9.37.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
+            "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
             }
         },
         "node_modules/@eslint/object-schema": {
@@ -572,13 +580,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-            "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+            "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.12.0",
+                "@eslint/core": "^0.16.0",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -648,183 +656,196 @@
             }
         },
         "node_modules/@napi-rs/canvas": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.65.tgz",
-            "integrity": "sha512-YcFhXQcp+b2d38zFOJNbpyPHnIL7KAEkhJQ+UeeKI5IpE9B8Cpf/M6RiHPQXSsSqnYbrfFylnW49dyh2oeSblQ==",
-            "optional": true,
-            "peer": true,
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+            "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "e2e/*"
+            ],
             "engines": {
                 "node": ">= 10"
             },
             "optionalDependencies": {
-                "@napi-rs/canvas-android-arm64": "0.1.65",
-                "@napi-rs/canvas-darwin-arm64": "0.1.65",
-                "@napi-rs/canvas-darwin-x64": "0.1.65",
-                "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.65",
-                "@napi-rs/canvas-linux-arm64-gnu": "0.1.65",
-                "@napi-rs/canvas-linux-arm64-musl": "0.1.65",
-                "@napi-rs/canvas-linux-riscv64-gnu": "0.1.65",
-                "@napi-rs/canvas-linux-x64-gnu": "0.1.65",
-                "@napi-rs/canvas-linux-x64-musl": "0.1.65",
-                "@napi-rs/canvas-win32-x64-msvc": "0.1.65"
+                "@napi-rs/canvas-android-arm64": "0.1.80",
+                "@napi-rs/canvas-darwin-arm64": "0.1.80",
+                "@napi-rs/canvas-darwin-x64": "0.1.80",
+                "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+                "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+                "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+                "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+                "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+                "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+                "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
             }
         },
         "node_modules/@napi-rs/canvas-android-arm64": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.65.tgz",
-            "integrity": "sha512-ZYwqFYEKcT5Zr8lbiaJNJj/poLaeK2TncolY914r+gD2TJNeP7ZqvE7A2SX/1C9MB4E3DQEwm3YhL3WEf0x3MQ==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+            "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@napi-rs/canvas-darwin-arm64": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.65.tgz",
-            "integrity": "sha512-Pg1pfiJEyDIsX+V0QaJPRWvXbw5zmWAk3bivFCvt/5pwZb37/sT6E/RqPHT9NnqpDyKW6SriwY9ypjljysUA1Q==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+            "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@napi-rs/canvas-darwin-x64": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.65.tgz",
-            "integrity": "sha512-3Tr+/HjdJN7Z/VKIcsxV2DvDIibZCExgfYTgljCkUSFuoI7iNkOE6Dc1Q6j212EB9PeO8KmfrViBqHYT6IwWkA==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+            "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.65.tgz",
-            "integrity": "sha512-3KP+dYObH7CVkZMZWwk1WX9jRjL+EKdQtD43H8MOI+illf+dwqLlecdQ4d9bQRIxELKJ8dyPWY4fOp/Ngufrdg==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+            "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
             "cpu": [
                 "arm"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.65.tgz",
-            "integrity": "sha512-Ka3StKz7Dq7kjTF3nNJCq43UN/VlANS7qGE3dWkn1d+tQNsCRy/wRmyt1TUFzIjRqcTFMQNRbgYq84+53UBA0A==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+            "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.65.tgz",
-            "integrity": "sha512-O4xMASm2JrmqYoiDyxVWi+z5C14H+oVEag2rZ5iIA67dhWqYZB+iO7wCFpBYRj31JPBR29FOsu6X9zL+DwBFdw==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+            "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.65.tgz",
-            "integrity": "sha512-dblWDaA59ZU8bPbkfM+riSke7sFbNZ70LEevUdI5rgiFEUzYUQlU34gSBzemTACj5rCWt1BYeu0GfkLSjNMBSw==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+            "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.65.tgz",
-            "integrity": "sha512-wsp+atutw13OJXGU3DDkdngtBDoEg01IuK5xMe0L6VFPV8maGkh17CXze078OD5QJOc6kFyw3DDscMLOPF8+oA==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+            "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@napi-rs/canvas-linux-x64-musl": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.65.tgz",
-            "integrity": "sha512-odX+nN+IozWzhdj31INcHz3Iy9+EckNw+VqsZcaUxZOTu7/3FmktRNI6aC1qe5minZNv1m05YOS1FVf7fvmjlA==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+            "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
         },
         "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-            "version": "0.1.65",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.65.tgz",
-            "integrity": "sha512-RZQX3luWnlNWgdMnLMQ1hyfQraeAn9lnxWWVCHuUM4tAWEV8UDdeb7cMwmJW7eyt8kAosmjeHt3cylQMHOxGFg==",
+            "version": "0.1.80",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+            "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1467,7 +1488,7 @@
             "version": "3.5.42",
             "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
             "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==",
-            "peer": true
+            "dev": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.6",
@@ -1482,16 +1503,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/localforage": {
-            "version": "0.0.34",
-            "resolved": "https://registry.npmjs.org/@types/localforage/-/localforage-0.0.34.tgz",
-            "integrity": "sha512-tJxahnjm9dEI1X+hQSC5f2BSd/coZaqbIl1m3TCl0q9SVuC52XcXfV0XmoCU1+PmjyucuVITwoTnN8OlTbEXXA==",
-            "deprecated": "This is a stub types definition for localforage (https://github.com/localForage/localForage). localforage provides its own type definitions, so you don't need @types/localforage installed!",
-            "peer": true,
-            "dependencies": {
-                "localforage": "*"
-            }
-        },
         "node_modules/@types/node": {
             "version": "22.13.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
@@ -1502,12 +1513,21 @@
                 "undici-types": "~6.20.0"
             }
         },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/react": {
-            "version": "19.0.2",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
-            "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
-            "peer": true,
+            "version": "18.3.26",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
+            "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
+                "@types/prop-types": "*",
                 "csstype": "^3.0.2"
             }
         },
@@ -1650,9 +1670,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1717,21 +1737,12 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@xmldom/xmldom": {
-            "version": "0.7.13",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
-            "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-            "deprecated": "this version is no longer supported, please update to at least 0.8.*",
-            "peer": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/acorn": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1744,6 +1755,7 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
+            "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -1790,6 +1802,16 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/ansis": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
+            "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1811,14 +1833,14 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-            "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
+                "form-data": "^4.0.4",
                 "proxy-from-env": "^1.1.0"
             }
         },
@@ -1843,10 +1865,11 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1865,23 +1888,23 @@
             }
         },
         "node_modules/bumpp": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/bumpp/-/bumpp-10.0.3.tgz",
-            "integrity": "sha512-5ONBZenNf9yfTIl2vFvDEfeeioidt0fG10SzjHQw50BRxOmXzsdY+lab1+SDMfiW6UyJ1xQqzFymcy5wa8YhTA==",
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/bumpp/-/bumpp-10.3.1.tgz",
+            "integrity": "sha512-cOKPRFCWvHcYPJQAHN6V7Jp/wAfnyqQRXQ+2fgWIL6Gao20rpu7xQ1cGGo1APOfmbQmmHngEPg9Fy7nJ3giRkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "ansis": "^4.2.0",
                 "args-tokenizer": "^0.3.0",
-                "c12": "^2.0.1",
+                "c12": "^3.3.0",
                 "cac": "^6.7.14",
                 "escalade": "^3.2.0",
-                "js-yaml": "^4.1.0",
                 "jsonc-parser": "^3.3.1",
-                "package-manager-detector": "^0.2.9",
-                "prompts": "^2.4.2",
-                "semver": "^7.7.1",
-                "tinyexec": "^0.3.2",
-                "tinyglobby": "^0.2.10"
+                "package-manager-detector": "^1.3.0",
+                "semver": "^7.7.2",
+                "tinyexec": "^1.0.1",
+                "tinyglobby": "^0.2.15",
+                "yaml": "^2.8.1"
             },
             "bin": {
                 "bumpp": "bin/bumpp.mjs"
@@ -1890,105 +1913,31 @@
                 "node": ">=18"
             }
         },
-        "node_modules/bumpp/node_modules/c12": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/c12/-/c12-2.0.4.tgz",
-            "integrity": "sha512-3DbbhnFt0fKJHxU4tEUPmD1ahWE4PWPMomqfYsTJdrhpmEnRKJi3qSC4rO5U6E6zN1+pjBY7+z8fUmNRMaVKLw==",
+        "node_modules/bumpp/node_modules/tinyexec": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+            "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chokidar": "^4.0.3",
-                "confbox": "^0.1.8",
-                "defu": "^6.1.4",
-                "dotenv": "^16.4.7",
-                "giget": "^1.2.4",
-                "jiti": "^2.4.2",
-                "mlly": "^1.7.4",
-                "ohash": "^2.0.4",
-                "pathe": "^2.0.3",
-                "perfect-debounce": "^1.0.0",
-                "pkg-types": "^1.3.1",
-                "rc9": "^2.1.2"
-            },
-            "peerDependencies": {
-                "magicast": "^0.3.5"
-            },
-            "peerDependenciesMeta": {
-                "magicast": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/bumpp/node_modules/giget": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/giget/-/giget-1.2.5.tgz",
-            "integrity": "sha512-r1ekGw/Bgpi3HLV3h1MRBIlSAdHoIMklpaQ3OQLFcRw9PwAj2rqigvIbg+dBUI51OxVI2jsEtDywDBjSiuf7Ug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "citty": "^0.1.6",
-                "consola": "^3.4.0",
-                "defu": "^6.1.4",
-                "node-fetch-native": "^1.6.6",
-                "nypm": "^0.5.4",
-                "pathe": "^2.0.3",
-                "tar": "^6.2.1"
-            },
-            "bin": {
-                "giget": "dist/cli.mjs"
-            }
-        },
-        "node_modules/bumpp/node_modules/nypm": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.5.4.tgz",
-            "integrity": "sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "citty": "^0.1.6",
-                "consola": "^3.4.0",
-                "pathe": "^2.0.3",
-                "pkg-types": "^1.3.1",
-                "tinyexec": "^0.3.2",
-                "ufo": "^1.5.4"
-            },
-            "bin": {
-                "nypm": "dist/cli.mjs"
-            },
-            "engines": {
-                "node": "^14.16.0 || >=16.10.0"
-            }
-        },
-        "node_modules/bumpp/node_modules/pkg-types": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "confbox": "^0.1.8",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.1"
-            }
+            "license": "MIT"
         },
         "node_modules/c12": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/c12/-/c12-3.0.2.tgz",
-            "integrity": "sha512-6Tzk1/TNeI3WBPpK0j/Ss4+gPj3PUJYbWl/MWDJBThFvwNGNkXtd7Cz8BJtD4aRwoGHtzQD0SnxamgUiBH0/Nw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.0.tgz",
+            "integrity": "sha512-K9ZkuyeJQeqLEyqldbYLG3wjqwpw4BVaAqvmxq3GYKK0b1A/yYQdIcJxkzAOWcNVWhJpRXAPfZFueekiY/L8Dw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^4.0.3",
-                "confbox": "^0.1.8",
+                "confbox": "^0.2.2",
                 "defu": "^6.1.4",
-                "dotenv": "^16.4.7",
-                "exsolve": "^1.0.0",
+                "dotenv": "^17.2.2",
+                "exsolve": "^1.0.7",
                 "giget": "^2.0.0",
-                "jiti": "^2.4.2",
-                "ohash": "^2.0.5",
+                "jiti": "^2.5.1",
+                "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "perfect-debounce": "^1.0.0",
-                "pkg-types": "^2.0.0",
+                "perfect-debounce": "^2.0.0",
+                "pkg-types": "^2.3.0",
                 "rc9": "^2.1.2"
             },
             "peerDependencies": {
@@ -2029,6 +1978,7 @@
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -2063,16 +2013,6 @@
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/citty": {
@@ -2130,12 +2070,13 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/confbox": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+            "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -2149,22 +2090,12 @@
                 "node": "^14.18.0 || >=16.10.0"
             }
         },
-        "node_modules/core-js": {
-            "version": "3.39.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
-            "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
-            "hasInstallScript": true,
-            "peer": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -2184,13 +2115,15 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/d": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
             "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
-            "peer": true,
+            "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "es5-ext": "^0.10.64",
                 "type": "^2.7.2"
@@ -2247,9 +2180,9 @@
             "license": "MIT"
         },
         "node_modules/dotenv": {
-            "version": "16.4.7",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-            "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+            "version": "17.2.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+            "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -2276,18 +2209,13 @@
         },
         "node_modules/epubjs": {
             "version": "0.3.93",
-            "resolved": "https://registry.npmjs.org/epubjs/-/epubjs-0.3.93.tgz",
-            "integrity": "sha512-c06pNSdBxcXv3dZSbXAVLE1/pmleRhOT6mXNZo6INKmvuKpYB65MwU/lO7830czCtjIiK9i+KR+3S+p0wtljrw==",
-            "peer": true,
+            "resolved": "git+ssh://git@github.com/zotero/epub.js.git#a6139d586b66d404f3da2b846598960c0394afc5",
+            "integrity": "sha512-9VSo7BBmdL+qh5udx7Gta7rrll/xAhodgQhtmX/1FGaS8xtZ5rD+hTxkj0opjSW9AF2GLIEQA6dZoPZqIwApww==",
+            "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "@types/localforage": "0.0.34",
-                "@xmldom/xmldom": "^0.7.5",
-                "core-js": "^3.18.3",
                 "event-emitter": "^0.3.5",
                 "jszip": "^3.7.1",
-                "localforage": "^1.10.0",
-                "lodash": "^4.17.21",
-                "marks-pane": "^1.0.9",
                 "path-webpack": "0.0.3"
             }
         },
@@ -2355,8 +2283,9 @@
             "version": "0.10.64",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
             "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+            "dev": true,
             "hasInstallScript": true,
-            "peer": true,
+            "license": "ISC",
             "dependencies": {
                 "es6-iterator": "^2.0.3",
                 "es6-symbol": "^3.1.3",
@@ -2371,7 +2300,8 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
             "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-            "peer": true,
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "d": "1",
                 "es5-ext": "^0.10.35",
@@ -2382,7 +2312,8 @@
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
             "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
-            "peer": true,
+            "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "d": "^1.0.2",
                 "ext": "^1.7.0"
@@ -2455,20 +2386,20 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.22.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.22.0.tgz",
-            "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
+            "version": "9.37.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
+            "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.19.2",
-                "@eslint/config-helpers": "^0.1.0",
-                "@eslint/core": "^0.12.0",
-                "@eslint/eslintrc": "^3.3.0",
-                "@eslint/js": "9.22.0",
-                "@eslint/plugin-kit": "^0.2.7",
+                "@eslint/config-array": "^0.21.0",
+                "@eslint/config-helpers": "^0.4.0",
+                "@eslint/core": "^0.16.0",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "9.37.0",
+                "@eslint/plugin-kit": "^0.4.0",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -2479,9 +2410,9 @@
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.3.0",
-                "eslint-visitor-keys": "^4.2.0",
-                "espree": "^10.3.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
                 "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -2516,9 +2447,9 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-            "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2533,10 +2464,11 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -2548,7 +2480,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
             "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-            "peer": true,
+            "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "d": "^1.0.1",
                 "es5-ext": "^0.10.62",
@@ -2560,15 +2493,15 @@
             }
         },
         "node_modules/espree": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.14.0",
+                "acorn": "^8.15.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.2.0"
+                "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2594,6 +2527,7 @@
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -2623,16 +2557,17 @@
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
             "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-            "peer": true,
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "d": "1",
                 "es5-ext": "~0.10.14"
             }
         },
         "node_modules/exsolve": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.4.tgz",
-            "integrity": "sha512-xsZH6PXaER4XoV+NiT7JHp1bJodJVT+cxeSH1G0f0tlT0lJqYuHUP3bUx2HtfTDvOagMINYp8rsqusxud3RXhw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+            "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
             "dev": true,
             "license": "MIT"
         },
@@ -2640,7 +2575,8 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
             "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-            "peer": true,
+            "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "type": "^2.7.2"
             }
@@ -2666,7 +2602,8 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.2",
@@ -2700,7 +2637,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -2798,15 +2736,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -2826,32 +2765,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/function-bind": {
@@ -3042,13 +2955,15 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
             "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -3073,7 +2988,8 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "peer": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
@@ -3109,7 +3025,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -3118,10 +3035,11 @@
             "dev": true
         },
         "node_modules/jiti": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-            "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -3181,7 +3099,8 @@
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
             "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-            "peer": true,
+            "dev": true,
+            "license": "(MIT OR GPL-3.0-or-later)",
             "dependencies": {
                 "lie": "~3.3.0",
                 "pako": "~1.0.2",
@@ -3196,16 +3115,6 @@
             "dev": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
-            }
-        },
-        "node_modules/kleur": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/levn": {
@@ -3225,25 +3134,8 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
             "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-            "peer": true,
-            "dependencies": {
-                "immediate": "~3.0.5"
-            }
-        },
-        "node_modules/localforage": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-            "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-            "peer": true,
-            "dependencies": {
-                "lie": "3.1.1"
-            }
-        },
-        "node_modules/localforage/node_modules/lie": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-            "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-            "peer": true,
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "immediate": "~3.0.5"
             }
@@ -3263,23 +3155,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "peer": true
-        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
-        },
-        "node_modules/marks-pane": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/marks-pane/-/marks-pane-1.0.9.tgz",
-            "integrity": "sha512-Ahs4oeG90tbdPWwAJkAAoHg2lRR8lAs9mZXETNPO9hYg3AkjUJBKi1NQ4aaIQZVGrig7c/3NUV1jANl8rFTeMg==",
-            "peer": true
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
@@ -3341,86 +3221,12 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/minipass": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minizlib/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/mlly": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-            "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.14.0",
-                "pathe": "^2.0.1",
-                "pkg-types": "^1.3.0",
-                "ufo": "^1.5.4"
-            }
-        },
-        "node_modules/mlly/node_modules/pkg-types": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "confbox": "^0.1.8",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.1"
             }
         },
         "node_modules/ms": {
@@ -3439,7 +3245,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
             "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-            "peer": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/node-fetch-native": {
             "version": "1.6.6",
@@ -3545,26 +3352,25 @@
             }
         },
         "node_modules/package-manager-detector": {
-            "version": "0.2.11",
-            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
-            "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.4.0.tgz",
+            "integrity": "sha512-rRZ+pR1Usc+ND9M2NkmCvE/LYJS+8ORVV9X0KuNSY/gFsp7RBHJM/ADh9LYq4Vvfq6QkKrW6/weuh8SMEtN5gw==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "quansync": "^0.2.7"
-            }
+            "license": "MIT"
         },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-            "peer": true
+            "dev": true,
+            "license": "(MIT AND Zlib)"
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -3605,7 +3411,8 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/path-webpack/-/path-webpack-0.0.3.tgz",
             "integrity": "sha512-AmeDxedoo5svf7aB3FYqSAKqMxys014lVKBzy1o/5vv9CtU7U4wgGWL1dA2o6MOzcD53ScN4Jmiq6VbtLz1vIQ==",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/pathe": {
             "version": "2.0.3",
@@ -3615,21 +3422,17 @@
             "license": "MIT"
         },
         "node_modules/pdfjs-dist": {
-            "version": "4.9.155",
-            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.9.155.tgz",
-            "integrity": "sha512-epRZn6DQQKCOEqbmFsxkiMBm1MHaNrnr6T4VBNP0bsDvdJdmrWcZbS5cgJXW68P0d3uJTlFhF6Wms2tlSgPYig==",
-            "peer": true,
+            "resolved": "git+ssh://git@github.com/zotero-plugin-dev/zotero-pdfjs-types.git#8aa68e6e7936550ee557d530b074bc861f22247a",
+            "dev": true,
+            "license": "MPL-2.0",
             "engines": {
-                "node": ">=20"
-            },
-            "optionalDependencies": {
-                "@napi-rs/canvas": "^0.1.64"
+                "node": ">=18"
             }
         },
         "node_modules/perfect-debounce": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-            "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
+            "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
             "dev": true,
             "license": "MIT"
         },
@@ -3646,23 +3449,16 @@
             }
         },
         "node_modules/pkg-types": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.1.0.tgz",
-            "integrity": "sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+            "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "confbox": "^0.2.1",
-                "exsolve": "^1.0.1",
+                "confbox": "^0.2.2",
+                "exsolve": "^1.0.7",
                 "pathe": "^2.0.3"
             }
-        },
-        "node_modules/pkg-types/node_modules/confbox": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.1.tgz",
-            "integrity": "sha512-hkT3yDPFbs95mNCy1+7qNKC6Pro+/ibzYxtM2iqEigpf0sVw+bg4Zh9/snjsBcf990vfIsg5+1U7VyiyBb3etg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
@@ -3702,21 +3498,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "peer": true
-        },
-        "node_modules/prompts": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.5"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
+            "license": "MIT"
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
@@ -3730,26 +3513,10 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/quansync": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.8.tgz",
-            "integrity": "sha512-4+saucphJMazjt7iOM27mbFCk+D9dd/zmgMDCzRZ8MEoBfYp7lAvoN38et/phRQF6wOPMy/OROBGgoWeSKyluA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/antfu"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/sxzz"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -3786,7 +3553,8 @@
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "peer": true,
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -3816,6 +3584,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
@@ -3857,7 +3626,8 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/semiff": {
             "version": "2.0.0",
@@ -3867,9 +3637,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -3883,7 +3653,8 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
             "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -3906,13 +3677,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/sisteransi": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/std-env": {
             "version": "3.8.1",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
@@ -3924,7 +3688,8 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "peer": true,
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -3934,6 +3699,7 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -3951,24 +3717,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/tar": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/tiny-update-notifier": {
@@ -3989,14 +3737,14 @@
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-            "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.3",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -4006,11 +3754,14 @@
             }
         },
         "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.4.3",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-            "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -4021,9 +3772,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4072,7 +3823,8 @@
             "version": "2.7.3",
             "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
             "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-            "peer": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -4123,13 +3875,6 @@
                 "typescript": ">=4.8.4 <5.9.0"
             }
         },
-        "node_modules/ufo": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
-            "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/undici-types": {
             "version": "6.20.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
@@ -4165,6 +3910,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -4183,7 +3929,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/util/node_modules/inherits": {
             "version": "2.0.3",
@@ -4226,12 +3973,18 @@
                 "node": ">=20.17.0"
             }
         },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+        "node_modules/yaml": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            }
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
@@ -4284,27 +4037,26 @@
             }
         },
         "node_modules/zotero-plugin-toolkit": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/zotero-plugin-toolkit/-/zotero-plugin-toolkit-4.1.2.tgz",
-            "integrity": "sha512-zM2NR6BLQKIAPa6Q0u6xdyIqjfwe9fz5lbJvg+fXN7B3m20ymC7wFyn1CJVzMCNCJitzr3K+obkyCvMYhiVDFQ==",
+            "version": "5.1.0-beta.10",
+            "resolved": "https://registry.npmjs.org/zotero-plugin-toolkit/-/zotero-plugin-toolkit-5.1.0-beta.10.tgz",
+            "integrity": "sha512-ubarvxwFVnkR/5piOZH/wd2w/51kkFXN+xu/NWnZs+1cnCSfMVClmecb+EaO4KX+tcydlVahVkrE5S3u/2VX9w==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
-            },
-            "peerDependencies": {
-                "zotero-types": "^3.1.0"
             }
         },
         "node_modules/zotero-types": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/zotero-types/-/zotero-types-3.1.7.tgz",
-            "integrity": "sha512-UBTRK2S+4rQlseLs2a3gBVhK+r3pQGd1Rmg0HASU5N9ZAXD6pMAT9lxi8EfR0iRTzB4rf9aZAXHkGOoK2WZnog==",
+            "version": "4.1.0-beta.4",
+            "resolved": "https://registry.npmjs.org/zotero-types/-/zotero-types-4.1.0-beta.4.tgz",
+            "integrity": "sha512-Dn8AKJQDeEGiDkCI8OT9+Lh1xnqa+JhBqcMBOPJcS2Ycpz40P5YH/BtHviUWzodKyvqwcseDwgOburaTVujeXg==",
+            "dev": true,
             "license": "MIT",
-            "peerDependencies": {
-                "@types/bluebird": "*",
-                "@types/react": "*",
-                "epubjs": "*",
-                "pdfjs-dist": "*"
+            "dependencies": {
+                "@types/bluebird": "^3.5.42",
+                "@types/react": "^18.3.26",
+                "bumpp": "^10.3.1",
+                "epubjs": "github:zotero/epub.js#a6139d586b66d404f3da2b846598960c0394afc5",
+                "pdfjs-dist": "github:zotero-plugin-dev/zotero-pdfjs-types#8aa68e6"
             }
         }
     }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -29,7 +29,7 @@
         "update-deps": "npm update --save"
     },
     "dependencies": {
-        "zotero-plugin-toolkit": "^4.1.2"
+        "zotero-plugin-toolkit": "^5.1.0-beta.10"
     },
     "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -42,7 +42,8 @@
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.26.0",
         "zotero-plugin-scaffold": "^0.3.2",
-        "zotero-types": "^3.1.7"
+        "zotero-types": "^4.1.0-beta.4",
+        "@napi-rs/canvas": "^0.1.80"
     },
     "prettier": {
         "printWidth": 80,

--- a/plugin/src/addon.ts
+++ b/plugin/src/addon.ts
@@ -3,8 +3,8 @@ import { config } from "../package.json";
 import {
     ColumnOptions,
     VirtualizedTableHelper,
-} from "zotero-plugin-toolkit/dist/helpers/virtualizedTable";
-import { DialogHelper } from "zotero-plugin-toolkit/dist/helpers/dialog";
+    DialogHelper,
+} from "zotero-plugin-toolkit";
 import hooks from "./hooks";
 import { createZToolkit } from "./utils/ztoolkit";
 import { LLMApiData } from "./modules/llmApiManager";

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -5,6 +5,7 @@
         "target": "ES2016",
         "resolveJsonModule": true,
         "skipDefaultLibCheck": true,
+        "skipLibCheck": true,
         "strict": true
     },
     "include": ["src", "typings", "node_modules/zotero-types"],

--- a/plugin/typings/epubjs-locations.d.ts
+++ b/plugin/typings/epubjs-locations.d.ts
@@ -1,0 +1,9 @@
+declare module "epubjs/types/locations" {
+    const Locations: any;
+    export default Locations;
+}
+
+declare module "epubjs/types/locator" {
+    const Locator: any;
+    export default Locator;
+}


### PR DESCRIPTION
- Bump zotero-plugin-toolkit to v5.1.0-beta.10
- Upgrade zotero-types to ^4.1.0-beta.4
- Add @napi-rs/canvas ^0.1.80 to devDependencies to satisfy pdfjs types
- Update imports to use toolkit root exports (remove deep /dist/helpers/... imports)
- Add ambient shim typings/epubjs-locations.d.ts and set skipLibCheck in tsconfig.json to avoid third-party .d.ts failures
- Set strict_max_version to "8" in build/update.json and update addon/manifest.json to "8.*"
- Ran npm install and npx tsc --noEmit to validate typecheck

Have tested in Zotero.

<img width="1534" height="1127" alt="image" src="https://github.com/user-attachments/assets/fbbd2e77-58b3-440a-9f13-a64c488ea1eb" />
<img width="970" height="1047" alt="image" src="https://github.com/user-attachments/assets/5a05b490-ab5a-4e10-af78-ab657a9f86d4" />
<img width="1745" height="602" alt="image" src="https://github.com/user-attachments/assets/4eee561a-0b5f-4a7a-a89d-762f464e3040" />
