### PR TITLE
Pick commits of [Update venv.py & Fix some bugs]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-  "editor.formatOnType": false,
-  "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },

--- a/server/utils/venv.py
+++ b/server/utils/venv.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 # e.g. "pdf2zh": { "conda": { "packages": [...], "python_version": "3.12" } }
 
 # TODO: 如果用户的conda/uv环境路径是自定义的, 需要支持自定义路径
-# 目前我们默认为当用户在命令行中执行uv / conda时, 是可以正常使用的, 而不是执行/usr/local/bin/uv等等才可以使用
+# 目前默认为当用户在命令行中执行uv / conda时, 是可以正常使用的, 而不是执行/usr/local/bin/uv等等才可以使用
 
 def normalize_pkg_name(name: str) -> str:
     return name.lower().replace('_', '-').replace('.', '-').split("=")[0] # .split("=")[0] 去掉==分隔的版本号等
@@ -48,7 +48,6 @@ class VirtualEnvManager:
         self.config_path = config_path
         self.skip_install = skip_install
         self.mirror_source = mirror_source
-        self.mirror_source = mirror_source
 
         with open(config_path, 'r', encoding='utf-8') as f:
             self.env_configs = json.load(f)
@@ -75,7 +74,7 @@ class VirtualEnvManager:
                 python_path = os.path.join(envname, 'Scripts' if self.is_windows else 'bin', python_executable)
                 # command_run = ['uv', 'pip', 'list', '--format=json', '--python', python_path]
             elif envtool == 'conda':
-                python_path = f'"{os.path.join(self.conda_env_path[self.curr_envname], '' if self.is_windows else 'bin', python_executable)}"'
+                python_path = os.path.join(self.conda_env_path[self.curr_envname], '' if self.is_windows else 'bin', python_executable)
                 # command_run = ['conda', 'run', '-n', envname, 'pip', 'list', '--format=json']
             command_run = [python_path, "-c",
                 "from utils.venv import check_packages_python_snippet; "
@@ -119,7 +118,7 @@ class VirtualEnvManager:
 
         try:
             env = os.environ.copy()
-            env['UV_HTTP_TIMEOUT'] = '7200' if envtool == 'uv' else None
+            env['UV_HTTP_TIMEOUT'] = '1200' if envtool == 'uv' else None
             if envtool == 'uv':
                 python_executable = 'python.exe' if self.is_windows else 'python'
                 python_path = os.path.join(envname, 'Scripts' if self.is_windows else 'bin', python_executable)
@@ -137,7 +136,7 @@ class VirtualEnvManager:
                     )
             elif envtool == 'conda':
                 python_executable = 'python.exe' if self.is_windows else 'python'
-                python_path = f'"{os.path.join(self.conda_env_path[self.curr_envname], '' if self.is_windows else 'bin', python_executable)}"'
+                python_path = os.path.join(self.conda_env_path[self.curr_envname], '' if self.is_windows else 'bin', python_executable)
                 if self.enable_mirror:
                     print("🌍 使用中科大镜像源安装 packages, 如果失败请在命令行参数中添加--enable_mirror=False")
                     subprocess.run(


### PR DESCRIPTION
此前的merge操作  [71a9101](https://github.com/guaguastandup/zotero-pdf2zh/commit/71a91010f3e5e82c7f4b2d1df1326cb997f089c0)   由于未知原因出现了错误，导致之前的commit修改内容未能进入主分支中。（ Pull Request #178 ）

排查发现分支涉及的文件中，有两个bat，一个server.py，一个venv.py，其中

两个bat没有修改，git存储在commit中，可能的原因是git设置中签出CR/LF模式与文件的CR/LF模式与操作系统写入文件的CR/LF模式有冲突导致git检测为修改了文件

server.py中作者添加了一个主分支中的修改，漏掉了一些主分支中的修改，虽然最后也并没有合并进入主分支，因此主分支上也没有遗漏内容。

venv.py中我的提交没有合并到主分支中，作者的引号patch也没有写入。因此此次检查主要将venv.py中的修改重新写为一个普通commit再次提交。

> 此外，在此前错误的merge commit [71a9101](https://github.com/guaguastandup/zotero-pdf2zh/commit/71a91010f3e5e82c7f4b2d1df1326cb997f089c0) 中，由于未知的错误导致有一些行重复了，作者在后续的主分支零散commit逐个修正了，但是漏掉了一个 `self.mirror_source = mirror_source` 重复了一行。

此次检查了粉色分支涉及的相关文件内容修改，重新提交到最新head

<img width="506" height="734" alt="image" src="https://github.com/user-attachments/assets/20953611-ca92-428e-b577-dd6ca39aec48" />

操作方式：

在最新版本venv.py的基础上添加我的修改，通过cherry-pick应用我之前的commit中的内容

`git cherry-pick ffb35ae58822ae459d2a08598e8f51324cd920fb`

然后手动解决冲突，然后`git cherry-pick --continue`再创建commit

但是通过这个设置的自动应用修改和合并后的文件可能仍有问题，因此与我的版本`ffb35ae`以及merge前的分支版本`5e19a59`中的venv.py再次比对，确认没有从两方拉过来的多余的代码。

> 另外，为何要在`.vscode/settings.json`中设置`"editor.formatOnSave": true`？我每次保存python文件都会被autopep8自动格式化，vscode中的设置里也是formatOnSave关闭了的。找到是谁格式化了代码和找到是哪里导致的自动格式化又花了一堆时间。这玩意居然会是.vscode里的设置。