### PR TITLE
docker2: simplify production config handling

### DIFF
--- a/docker2/Dockerfile
+++ b/docker2/Dockerfile
@@ -36,6 +36,6 @@ VOLUME ["/app/config", "/app/server/translated"]
 # 暴露新版 server.py 的默认端口
 EXPOSE 8890
 
-# 定义容器启动命令，并明确禁用 server.py 内部的 venv 管理
-
-CMD ["python", "server/server.py", "--enable_venv=False", "--port=8890"]
+# 定义容器启动命令，并明确禁用 server.py 内部的 venv 管理。
+# Docker 环境默认不做交互式更新检查，避免容器启动时等待用户输入。
+CMD ["python", "server/server.py", "--enable_venv=False", "--check_update=False", "--port=8890"]

--- a/docker2/README.md
+++ b/docker2/README.md
@@ -79,6 +79,8 @@ docker compose up -d
 
 服务启动需要一些时间，当您在日志中看到 `* Running on http://0.0.0.0:8890` 时，代表服务已准备就绪。
 
+> 说明：生产模式会默认关闭 `server.py` 的启动时更新检查，避免容器内出现交互式“是否立即更新”的提示，影响无人值守部署。
+
 ## 第三步：配置 Zotero 插件
 
 在 Zotero 插件设置中，将 **Python Server IP** 设置为 `http://localhost:8890` 即可开始使用。

--- a/docker2/README.md
+++ b/docker2/README.md
@@ -49,7 +49,7 @@ wget https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker2/
 wget https://raw.githubusercontent.com/guaguastandup/zotero-pdf2zh/main/docker2/Dockerfile
 
 # 3. 创建用于存放翻译文件的文件夹
-mkdir -p zotero-pdf2zh/config zotero-pdf2zh/translated
+mkdir -p zotero-pdf2zh/translated
 ```
 
 最终文件夹结构应如下：
@@ -59,8 +59,7 @@ zotero-pdf2zh/
 ├── docker-compose.yaml
 ├── Dockerfile
 └── zotero-pdf2zh/
-    └── translated/
-    ├── config/
+    ├── translated/
     └── LXGWWenKai-Regular.ttf # (可选) 将您的字体文件放在这里
 ```
 
@@ -79,7 +78,7 @@ docker compose up -d
 
 服务启动需要一些时间，当您在日志中看到 `* Running on http://0.0.0.0:8890` 时，代表服务已准备就绪。
 
-> 说明：生产模式会默认关闭 `server.py` 的启动时更新检查，避免容器内出现交互式“是否立即更新”的提示，影响无人值守部署。
+> 说明：生产模式会默认关闭 `server.py` 的启动时更新检查，避免容器内出现交互式“是否立即更新”的提示，影响无人值守部署。翻译配置由 Zotero 插件随请求传入，并在容器内部管理，普通用户无需额外准备 `config/` 目录。
 
 ## 第三步：配置 Zotero 插件
 

--- a/docker2/docker-compose.yaml
+++ b/docker2/docker-compose.yaml
@@ -18,10 +18,8 @@ services:
             - TZ=Asia/Shanghai
             - HF_ENDPOINT=https://hf-mirror.com
         volumes:
-            # 【最终更正版挂载路径】
-            # 1. 挂载翻译和配置文件：
+            # 1. 挂载翻译结果：
             - ./zotero-pdf2zh/translated:/app/server/translated
-            - ./zotero-pdf2zh/config:/app/server/config
             # 2. (可选) 挂载自定义字体:
             #    - 将字体文件放入本地的 zotero-pdf2zh 文件夹后，取消下面一行的注释
 


### PR DESCRIPTION
## Summary
- disable interactive update checks in docker2 production
- keep docker2 production config inside the container
- update docker2 README to match the new deployment flow

## Why
The docker2 production path should behave like a self-contained deployment. Users do not need to prepare or manage a host-side config directory because plugin settings are sent with each request and written by the server at runtime. Keeping `/app/server/config` inside the container also avoids the empty bind-mount issue behind #264.

## Changes
- add `--check_update=False` to the docker2 production startup command
- remove the default host bind mount for `/app/server/config`
- keep only `translated/` as the default host-side data directory
- update docker2 README accordingly

## Scope
This only affects the docker2 production deployment path.
