### PR TITLE
feat(progress): show babeldoc stage detail in dashboard

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -632,6 +632,11 @@
         return merged;
       }
       function toggleHistoryItem(el) { el.classList.toggle("expanded"); }
+      function escapeHtml(s) {
+        if (s === null || s === undefined) return "";
+        return String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+      }
+
       function toggleTaskConfig(btn) {
         const detail = btn.nextElementSibling;
         if (detail) {
@@ -709,7 +714,19 @@
               else { elapsed = formatDuration(Math.floor(((task.endTime?new Date(task.endTime):new Date()) - new Date(task.startTime)) / 1000)); }
             }
             let msgHtml = "";
-            if (task.message) { let mc = "task-message"; if(n.state==="failed") mc+=" error"; else if(n.state==="success") mc+=" success"; msgHtml = `<div class="${mc}" style="display:block">${task.message}</div>`; }
+            if (task.message) { let mc = "task-message"; if(n.state==="failed") mc+=" error"; else if(n.state==="success") mc+=" success"; msgHtml = `<div class="${mc}" style="display:block">${escapeHtml(task.message)}</div>`; }
+            // 详细阶段进度（来自子进程 stdout 解析）
+            // 仅在任务进行中显示, 已完成/失败的卡片不展示
+            let stageHtml = "";
+            if (task.stageName && task.stageTotal && (n.state==="active"||n.state==="running")) {
+              const stagePct = task.stageTotal > 0 ? Math.max(0, Math.min(100, Math.round(task.stageCurr / task.stageTotal * 100))) : 0;
+              const stageName = escapeHtml(task.stageName);
+              const stageCurr = escapeHtml(task.stageCurr);
+              const stageTotal = escapeHtml(task.stageTotal);
+              const elapsedTxt = task.stageElapsed ? ` · 已用 ${escapeHtml(task.stageElapsed)}` : "";
+              const eta = task.stageEta ? ` · 预计剩余 ${escapeHtml(task.stageEta)}` : "";
+              stageHtml = `<div class="task-message" style="display:block;background:#e3f2fd;color:#0d47a1;font-family:ui-monospace,monospace;font-size:12px"><strong>${stageName}</strong> ${stageCurr}/${stageTotal} (${stagePct}%)${elapsedTxt}${eta}<div class="task-progress-bar" style="margin-top:6px;height:4px"><div class="task-progress-fill" style="width:${stagePct}%;background:#0d47a1"></div></div></div>`;
+            }
             // 配置摘要
             let cfgHtml = '';
             if (task.config) {
@@ -717,17 +734,17 @@
               cfgHtml = `<div class="task-config-toggle ${isExpanded?'expanded':''}" onclick="toggleTaskConfig(this)">${isExpanded ? '收起配置 ▲' : '查看翻译配置 ▼'}</div><div class="task-config-detail ${isExpanded?'show':''} config-display">${renderConfigHtml(task.config)}</div>`;
             }
             return `<div class="${cardClass}" id="task-${taskId}">
-              <div class="task-header"><div class="task-filename">${task.fileName||"未知文件"}</div><div class="${badgeClass}">${badgeText}</div></div>
+              <div class="task-header"><div class="task-filename">${escapeHtml(task.fileName||"未知文件")}</div><div class="${badgeClass}">${escapeHtml(badgeText)}</div></div>
               <div class="task-progress-bar"><div class="task-progress-fill" style="width:${progress}%"></div></div>
               <div class="task-info">
                 <div class="task-info-item"><div class="task-info-label">进度</div><div class="task-info-value">${progress}%</div></div>
                 <div class="task-info-item"><div class="task-info-label">开始</div><div class="task-info-value">${formatTime(task.startTime)}</div></div>
-                <div class="task-info-item"><div class="task-info-label">引擎</div><div class="task-info-value">${task.engine||"-"}</div></div>
-                <div class="task-info-item"><div class="task-info-label">服务</div><div class="task-info-value">${task.service||"-"}</div></div>
-                <div class="task-info-item"><div class="task-info-label">模型</div><div class="task-info-value" title="${task.modelName||'-'}">${task.modelName||'默认模型'}</div></div>
+                <div class="task-info-item"><div class="task-info-label">引擎</div><div class="task-info-value">${escapeHtml(task.engine||"-")}</div></div>
+                <div class="task-info-item"><div class="task-info-label">服务</div><div class="task-info-value">${escapeHtml(task.service||"-")}</div></div>
+                <div class="task-info-item"><div class="task-info-label">模型</div><div class="task-info-value" title="${escapeHtml(task.modelName||'-')}">${escapeHtml(task.modelName||'默认模型')}</div></div>
                 <div class="task-info-item"><div class="task-info-label">耗时</div><div class="task-info-value">${elapsed}</div></div>
               </div>
-              ${msgHtml}${cfgHtml}
+              ${stageHtml}${msgHtml}${cfgHtml}
             </div>`;
           }).join("");
         }

--- a/server/utils/execute.py
+++ b/server/utils/execute.py
@@ -22,6 +22,15 @@ MAIN_PROGRESS_RE = re.compile(
 # Match step-like lines where only status message should be updated
 STEP_PROGRESS_RE = re.compile(r"(.+?)\(\d+/\d+\)\s+.*?(\d+)/(\d+)")
 
+# 详细阶段进度：抓 babeldoc rich progress 行
+# 例: "Automatic Term Extraction (1/1) ━━━━━━╸━━ 2274/2404 0:08:58 0:00:33"
+# 解析阶段名 / 当前 / 总数 / 已用时间 / 预计剩余
+# - 阶段名兼容字母 / 空格 / 连字符 / 数字 / 非 ASCII (例如未来本地化的 babeldoc)
+# - 但用首字符为字母约束避免抓到纯数字行
+STAGE_DETAIL_RE = re.compile(
+    r"([^\d\r\n][^()\r\n]{2,80}?)\s+\(\d+/\d+\)[^0-9\r\n]*?(\d+)/(\d+)\s+(\d+:\d+:\d+)(?:\s+(\d+:\d+:\d+))?",
+)
+
 # Legacy pdf2zh (1.x) progress format
 LEGACY_PROGRESS_RE = re.compile(r"(?:translate|Running|Parse).*?(\d+)/(\d+)", re.IGNORECASE)
 
@@ -109,6 +118,40 @@ def _parse_progress(text, task_id):
             # 【新增调试日志】记录 Main 正则抓到了什么
             # _debug_progress_log("MATCH_MAIN", curr=curr, total=total, pct=pct)
         return
+
+    # 详细阶段进度: 抓 babeldoc 子进程 rich 输出, 反向找最后一个未完成阶段
+    # （多阶段同时输出时, 已完成的阶段也在文本里, 不能取第一个匹配）
+    all_matches = STAGE_DETAIL_RE.findall(clean)
+    if all_matches:
+        chosen = None
+        for m in reversed(all_matches):
+            try:
+                if int(m[1]) < int(m[2]):
+                    chosen = m
+                    break
+            except Exception:
+                pass
+        if chosen is None:
+            chosen = all_matches[-1]
+        stage_name = chosen[0].strip()
+        try:
+            stage_curr = int(chosen[1])
+            stage_total = int(chosen[2])
+        except Exception:
+            stage_curr = stage_total = 0
+        elapsed = chosen[3]
+        eta = chosen[4] if len(chosen) > 4 else ""
+        if stage_total > 0:
+            task_manager.update_task(task_id, {
+                "status": "running",
+                "message": stage_name,
+                "stageName": stage_name,
+                "stageCurr": stage_curr,
+                "stageTotal": stage_total,
+                "stageElapsed": elapsed,
+                "stageEta": eta,
+            })
+            return
 
     # Step status text (secondary)
     match = STEP_PROGRESS_RE.search(clean)


### PR DESCRIPTION
## Problem
Dashboard at `http://127.0.0.1:8891/` shows only the overall "translate N/100" percentage. The babeldoc subprocess emits per-stage progress lines like `Automatic Term Extraction (1/1) ━━━╸ 2274/2404 0:08:58 0:00:33` but they're discarded. Users staring at "translate 88%" for 10 minutes have no way to know which sub-stage is running.

## Changes

**`server/utils/execute.py`**: add `STAGE_DETAIL_RE` to capture stage name + N/M + elapsed + ETA from rich progress lines. Use `findall` and walk in reverse to pick the latest non-completed stage (multiple stages can appear in the same flush).

**`server/index.html`**:
- Add a global `escapeHtml()` helper.
- Render a small blue strip under the main progress bar showing `<stage> N/M (xx%) · 已用 hh:mm:ss · 预计剩余 hh:mm:ss`.
- Strip is hidden when no stage detail parsed yet, and on completed/failed cards (only shows during `active`/`running`).
- All dynamic task fields entering `innerHTML` are now escaped: `task.message`, `task.fileName`, `badgeText`, `task.engine`, `task.service`, `task.modelName`, `task.stageName/stageCurr/stageTotal/stageElapsed/stageEta`.
- `stagePct` clamped to [0,100].

## Test plan
- [x] Translate a PDF, dashboard shows stage strip switching through Parse → Term Extraction → Translate Paragraphs → Render.
- [x] When a stage hits 100%, strip switches to next non-completed stage.
- [x] Failed task hides the stage strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)