### PR TITLE
feat(cache): expose babeldoc translation cache stats with caveats

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -726,6 +726,7 @@
                 <div class="task-info-item"><div class="task-info-label">服务</div><div class="task-info-value">${task.service||"-"}</div></div>
                 <div class="task-info-item"><div class="task-info-label">模型</div><div class="task-info-value" title="${task.modelName||'-'}">${task.modelName||'默认模型'}</div></div>
                 <div class="task-info-item"><div class="task-info-label">耗时</div><div class="task-info-value">${elapsed}</div></div>
+                ${(typeof task.cacheGlobalDelta === "number") ? `<div class="task-info-item"><div class="task-info-label">缓存增量(粗略)</div><div class="task-info-value" title="${task.cacheCaveat || ''}">+${task.cacheGlobalDelta} 段</div></div>` : ""}
               </div>
               ${msgHtml}${cfgHtml}
             </div>`;

--- a/server/server.py
+++ b/server/server.py
@@ -24,6 +24,7 @@ from datetime import datetime  # 用于记录任务开始/结束时间
 from utils.auto_update import check_for_updates, perform_update_optimized
 # 导入任务管理器（用于 index.html 前端进度显示）
 from utils.task_manager import task_manager
+from utils.cache_inspector import get_global_stats, count_entries
 # 导入带进度解析的命令执行器
 from utils.execute import execute_with_progress
 
@@ -91,6 +92,8 @@ class PDFTranslator:
         self.app.add_url_rule('/events', 'events', self.events)
         # 新增：历史记录 API - 供 index.html 前端获取翻译历史
         self.app.add_url_rule('/api/history', 'history', self.get_history)
+        # 缓存统计: GET /api/cache-stats 暴露 babeldoc 翻译缓存的全局信息
+        self.app.add_url_rule('/api/cache-stats', 'cache_stats', self.get_cache_stats)
         # 新增：配置信息 API - 供 index.html 前端显示当前服务配置
         self.app.add_url_rule('/api/config', 'config', self.get_config)
         # 新增：favicon 路由
@@ -145,6 +148,12 @@ class PDFTranslator:
     ##################################################################
     def get_history(self):
         return jsonify({'status': 'success', 'history': task_manager.get_history()})
+
+    ##################################################################
+    # GET /api/cache-stats - babeldoc 翻译缓存全局统计
+    ##################################################################
+    def get_cache_stats(self):
+        return jsonify({'status': 'success', 'cache': get_global_stats()})
 
     ##################################################################
     # 配置信息 API /api/config - 供 index.html 前端显示当前服务配置
@@ -273,6 +282,8 @@ class PDFTranslator:
                 else:
                     model_name = f'{service} (默认模型)'
 
+            # 缓存命中追踪: 记录翻译开始时的 babeldoc 缓存条目数, 完成时算差值
+            cache_before = count_entries()
             task_manager.add_task(task_id, {
                 'taskId': task_id,
                 'active': True,
@@ -284,7 +295,8 @@ class PDFTranslator:
                 'progress': 0,
                 'status': '开始翻译',
                 'message': '正在初始化...',
-                'config': config_summary
+                'config': config_summary,
+                'cacheBefore': cache_before,
             })
 
             # 辅助函数：仅当文件存在时添加到列表
@@ -394,6 +406,24 @@ class PDFTranslator:
                 return jsonify({'status': 'error', 'message': '操作失败，请查看详细日志。'}), 500
 
             fileNameList = [os.path.basename(p) for p in existing]
+            # 缓存 delta (粗略指标): 本次全局缓存条目数增量, 大致反映"真正调 LLM 的段落数".
+            # 已知 caveat:
+            #   - 并发翻译会互相计算对方增量, 数值偏大
+            #   - 不同 engine 共享同一表, 切换 engine 时增量混入其他翻译
+            #   - cache disabled / write fail 时增量为 0 但实际并未命中
+            # 因此返回字段叫 cacheGlobalDelta, 加 cacheCaveat 解释口径.
+            cache_after = count_entries()
+            try:
+                with task_manager.lock:
+                    if task_id in task_manager.active_tasks:
+                        cb = task_manager.active_tasks[task_id].get('cacheBefore')
+                        if cb is not None and cache_after is not None:
+                            task_manager.active_tasks[task_id]['cacheGlobalDelta'] = max(0, cache_after - cb)
+                            task_manager.active_tasks[task_id]['cacheCaveat'] = (
+                                'global delta; concurrent tasks share counter'
+                            )
+            except Exception:
+                pass
             # 更新任务状态为成功（前端会显示成功状态和生成的文件列表）
             task_manager.complete_task(
                 task_id,

--- a/server/utils/cache_inspector.py
+++ b/server/utils/cache_inspector.py
@@ -1,0 +1,92 @@
+"""Babeldoc 翻译缓存探查器: 暴露缓存条目数和翻译完成后的 delta。
+
+babeldoc 在 ~/.cache/babeldoc/cache.v1.db 维护一个 sqlite 表
+`_translationcache(translate_engine, translate_engine_params, original_text, translation)`，
+按 unique (engine, params, original_text) 缓存翻译结果。
+
+我们利用这个 db 给前端展示两类信息：
+
+1. 全局缓存规模（GET /api/cache-stats）—— 让用户知道缓存累积了多少条目。
+2. 单次翻译的 cache delta —— 翻译开始/结束时记录行数差，得出本次实际"新发起 LLM 调用"的段落数。
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import Optional
+
+# babeldoc 默认缓存路径; 若 BABELDOC_CACHE_DIR 环境变量被设置则用它
+def _candidate_paths():
+    """生成候选 db 路径. BABELDOC_CACHE_DIR 设置时只用它, 不再 fallback 默认路径
+    (Codex review #300 P2: 否则用户明确指定的位置无效但不知).
+    """
+    explicit = os.environ.get("BABELDOC_CACHE_DIR")
+    if explicit:
+        explicit = os.path.expanduser(explicit)
+        # 既支持指向目录也支持指向 .db 文件
+        if os.path.isdir(explicit):
+            return [os.path.join(explicit, "cache.v1.db")]
+        return [explicit]
+    return [os.path.expanduser("~/.cache/babeldoc/cache.v1.db")]
+
+
+def _find_db() -> Optional[str]:
+    for p in _candidate_paths():
+        if os.path.isfile(p):
+            return p
+    return None
+
+
+def get_global_stats() -> dict:
+    """返回全局缓存信息: 总条目数, 库文件大小 MB, 涉及的 engine 列表.
+
+    注意: 不返回 dbPath, 避免向 server 监听网络的客户端泄漏本机文件系统结构.
+    路径在 babeldoc 项目里是固定的 (~/.cache/babeldoc/cache.v1.db), 客户端
+    不需要它.
+    """
+    db = _find_db()
+    if not db:
+        return {"available": False, "reason": "babeldoc cache db not found"}
+    try:
+        size_bytes = os.path.getsize(db)
+        with sqlite3.connect(f"file:{db}?mode=ro", uri=True) as conn:
+            cur = conn.cursor()
+            total = cur.execute(
+                "SELECT COUNT(*) FROM _translationcache"
+            ).fetchone()[0]
+            engines = [
+                row[0]
+                for row in cur.execute(
+                    "SELECT DISTINCT translate_engine FROM _translationcache "
+                    "ORDER BY translate_engine"
+                )
+            ]
+        return {
+            "available": True,
+            # 不暴露 dbPath, 防止向局域网泄漏文件系统信息
+            "totalEntries": total,
+            "sizeMb": round(size_bytes / 1024 / 1024, 2),
+            "engines": engines,
+            "schemaTable": "_translationcache",  # 标明依赖的 babeldoc 内部 schema
+        }
+    except Exception as e:
+        # codex review #300 P2: 不返回 raw 异常文本, 因为 OSError/PermissionError 会
+        # 在 message 里嵌入完整文件路径 (例如 "Permission denied: '/Users/x/.cache/...'"),
+        # 这违反了 v2 移除 dbPath 的 LAN 信息隐藏目标. 服务端日志正常打印, 客户端只看通用错误码.
+        print(f"[cache_inspector] read failed: {e}", flush=True)
+        return {"available": False, "reason": "cache_db_read_error"}
+
+
+def count_entries() -> Optional[int]:
+    """快速返回当前缓存条目数, 失败返回 None"""
+    db = _find_db()
+    if not db:
+        return None
+    try:
+        with sqlite3.connect(f"file:{db}?mode=ro", uri=True) as conn:
+            return conn.execute(
+                "SELECT COUNT(*) FROM _translationcache"
+            ).fetchone()[0]
+    except Exception:
+        return None


### PR DESCRIPTION
## Problem
Babeldoc maintains a sqlite paragraph-level cache at `~/.cache/babeldoc/cache.v1.db`, but the server doesn't surface any cache metadata. After a long translation, users can't tell whether the next run will be fast (cache hit) or slow.

## Changes

**`server/utils/cache_inspector.py`** (new): opens the cache db read-only and returns `totalEntries`, `sizeMb`, `engines`, `schemaTable`. Includes a fast `count_entries()` for delta tracking. Read-only access throughout (`?mode=ro`); never writes.

**New endpoint `GET /api/cache-stats`**: returns global cache info. **Does not return `dbPath`** — server may bind 0.0.0.0, exposing the absolute filesystem path leaks user account name and directory layout.

**`/translate` flow**:
- Captures row count `cacheBefore` before starting.
- Writes delta `cacheGlobalDelta` into the task entry on success.
- Adds `cacheCaveat` field documenting that this is a global counter delta (concurrent tasks share it, cross-engine runs leak into each other).

**`server/index.html`**: shows the delta in the task card as **缓存增量(粗略)** with the caveat as tooltip. The label intentionally says "粗略" because the metric isn't exact (see caveat).

## Properties
- If db doesn't exist (fresh install) → `{available: false}`, no breakage.
- `BABELDOC_CACHE_DIR` env var now `expanduser`'d (was raw path before).
- `schemaTable: "_translationcache"` in response signals the babeldoc-internal dependency.

## Test plan
- [x] `GET /api/cache-stats` on fresh install → `{available: false}`.
- [x] After translating one PDF → `{available: true, totalEntries: N, sizeMb: ...}`.
- [x] Translate same PDF twice → second run shows `cacheGlobalDelta=0`.
- [x] No `dbPath` in response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)