### PR TITLE
fix: compatibility with Zotero 9 (Firefox 140 ESR)

### DIFF
--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "zotero-pdf2zh",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "zotero-pdf2zh",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "zotero-plugin-toolkit": "^5.1.0-beta.10"
+                "zotero-plugin-toolkit": "^5.1.2"
             },
             "devDependencies": {
                 "@eslint/js": "^9.22.0",
@@ -4037,9 +4037,9 @@
             }
         },
         "node_modules/zotero-plugin-toolkit": {
-            "version": "5.1.0-beta.10",
-            "resolved": "https://registry.npmjs.org/zotero-plugin-toolkit/-/zotero-plugin-toolkit-5.1.0-beta.10.tgz",
-            "integrity": "sha512-ubarvxwFVnkR/5piOZH/wd2w/51kkFXN+xu/NWnZs+1cnCSfMVClmecb+EaO4KX+tcydlVahVkrE5S3u/2VX9w==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/zotero-plugin-toolkit/-/zotero-plugin-toolkit-5.1.2.tgz",
+            "integrity": "sha512-mOxWGWCrwnkNoIAiXQv03La7pfiRyBeLmwbiQQDtm/6PvGAuRYZWTKahPPS+ORKblNs84lpMQ6CdPgwJm0ATZw==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zotero-pdf2zh",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "description": "Zotero Pdf2zh",
     "config": {
         "addonName": "Zotero Pdf2zh",
@@ -29,10 +29,11 @@
         "update-deps": "npm update --save"
     },
     "dependencies": {
-        "zotero-plugin-toolkit": "^5.1.0-beta.10"
+        "zotero-plugin-toolkit": "^5.1.2"
     },
     "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@napi-rs/canvas": "^0.1.80",
         "@types/node": "^22.13.10",
         "axios": "^1.8.2",
         "eslint": "^9.22.0",
@@ -42,8 +43,7 @@
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.26.0",
         "zotero-plugin-scaffold": "^0.3.2",
-        "zotero-types": "^4.1.0-beta.4",
-        "@napi-rs/canvas": "^0.1.80"
+        "zotero-types": "^4.1.0-beta.4"
     },
     "prettier": {
         "printWidth": 80,

--- a/plugin/src/modules/pdf2zh.ts
+++ b/plugin/src/modules/pdf2zh.ts
@@ -1,4 +1,3 @@
-import { MenuitemOptions } from "zotero-plugin-toolkit";
 import { getString } from "../utils/locale";
 
 export class PDF2zhBasicFactory {
@@ -37,19 +36,41 @@ export class PDF2zhUIFactory {
                 command: "crop-comparePDF",
             },
         ];
-        const pdf2zhMenu: MenuitemOptions = {
-            tag: "menu",
-            id: "zotero-itemmenu-pdf2zh",
-            icon: menuIcon,
-            label: `PDF2zh`,
-            children: MENU_ITEMS.map(({ id, label, command }) => ({
-                tag: "menuitem",
-                id: `zotero-itemmenu-${id}`,
-                label: `PDF2zh: ${label}`,
-                commandListener: () => addon.hooks.onDialogEvents(command),
-                icon: menuIcon,
-            })),
-        };
-        ztoolkit.Menu.register("item", pdf2zhMenu);
+
+        const doc = Zotero.getMainWindow().document;
+        const popup = doc.querySelector("#zotero-itemmenu");
+        if (!popup) return;
+
+        const menu = doc.createElementNS(
+            "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul",
+            "menu",
+        );
+        menu.id = "zotero-itemmenu-pdf2zh";
+        menu.setAttribute("label", "PDF2zh");
+        menu.setAttribute("image", menuIcon);
+        menu.classList.add("menu-iconic");
+
+        const subPopup = doc.createElementNS(
+            "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul",
+            "menupopup",
+        );
+
+        for (const item of MENU_ITEMS) {
+            const menuitem = doc.createElementNS(
+                "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul",
+                "menuitem",
+            );
+            menuitem.id = `zotero-itemmenu-${item.id}`;
+            menuitem.setAttribute("label", `PDF2zh: ${item.label}`);
+            menuitem.setAttribute("image", menuIcon);
+            menuitem.classList.add("menuitem-iconic");
+            menuitem.addEventListener("command", () =>
+                addon.hooks.onDialogEvents(item.command),
+            );
+            subPopup.appendChild(menuitem);
+        }
+
+        menu.appendChild(subPopup);
+        popup.appendChild(menu);
     }
 }

--- a/plugin/src/utils/ztoolkit.ts
+++ b/plugin/src/utils/ztoolkit.ts
@@ -1,7 +1,6 @@
 import {
     BasicTool,
     UITool,
-    MenuManager,
     ClipboardHelper,
     FilePickerHelper,
     ProgressWindowHelper,
@@ -42,7 +41,6 @@ function initZToolkit(_ztoolkit: ReturnType<typeof createZToolkit>) {
 
 class MyToolkit extends BasicTool {
     UI: UITool;
-    Menu: MenuManager;
     Clipboard: typeof ClipboardHelper;
     FilePicker: typeof FilePickerHelper;
     ProgressWindow: typeof ProgressWindowHelper;
@@ -54,7 +52,6 @@ class MyToolkit extends BasicTool {
     constructor() {
         super();
         this.UI = new UITool(this);
-        this.Menu = new MenuManager(this);
         this.Clipboard = ClipboardHelper;
         this.FilePicker = FilePickerHelper;
         this.ProgressWindow = ProgressWindowHelper;

--- a/plugin/zotero-plugin.config.ts
+++ b/plugin/zotero-plugin.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
                     __env__: `"${process.env.NODE_ENV}"`,
                 },
                 bundle: true,
-                target: "firefox115",
+                target: "firefox140",
                 outfile: `build/addon/content/scripts/${pkg.config.addonRef}.js`,
             },
         ],


### PR DESCRIPTION
## Summary

Fix plugin compatibility with Zotero 9 (based on Firefox 140 ESR). The current version (4.0.3) fails to install on Zotero 9.

## Changes

1. **Build target**: `firefox115` → `firefox140`
2. **zotero-plugin-toolkit**: `5.1.0-beta.10` → `5.1.2`
3. **Replace deprecated MenuManager** with native XUL menu API (MenuManager was removed in toolkit 5.1.1)
4. **Bump version**: 4.0.3 → 4.0.4

## Tested

- Build passes successfully
- Core translation functionality works on Zotero 9

## Note

Closes #291, #292