### PR TITLE
[closed] temporary Windows conda v4.1.0 hotfix validation

### DIFF
--- a/.github/scripts/apply_windows_conda_hotfix.py
+++ b/.github/scripts/apply_windows_conda_hotfix.py
@@ -7,24 +7,16 @@ def replace_once(text: str, old: str, new: str, label: str) -> str:
     return text.replace(old, new, 1)
 
 
-# The Windows Conda interpreter/PATH layout is already fixed on the review
-# branch.  This migration adds the second safety invariant: a failed optional
-# repair/update must not disable the old environment when it is still healthy.
+# Windows Conda interpreter/PATH layout is already fixed on the review branch.
+# This patch adds the second invariant: a failed optional update must not disable
+# the old environment when that runtime is still healthy.
 venv_path = Path("server/utils/venv.py")
 venv = venv_path.read_text(encoding="utf-8")
 venv = replace_once(
     venv,
     '''            if self.install_packages(engine, repair_tool):\n                return True\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
-    '''            if self.install_packages(engine, repair_tool):\n                return True\n\n            # Updating/repairing is a maintenance action.  If the transactional\n            # attempt fails, re-discover the original environment and keep using\n            # it whenever it is still healthy.  A failed update must not turn a\n            # previously working runtime into a translation outage.\n            restored = self._existing(engine, repair_tool)\n            if restored and self._requirements_ok(\n                engine, repair_tool, restored[2]\n            ):\n                self._remember_environment(engine, repair_tool, restored[1])\n                print(\n                    f"⚠️ {repair_tool} 安全更新失败，但原有 {engine} 环境仍可用；"\n                    "本次继续使用原环境。"\n                )\n                return True\n\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
+    '''            if self.install_packages(engine, repair_tool):\n                return True\n\n            # Updating/repairing is a maintenance action. If the transactional\n            # attempt fails, re-discover the original environment and keep using\n            # it whenever it is still healthy. A failed update must not turn a\n            # previously working runtime into a translation outage.\n            restored = self._existing(engine, repair_tool)\n            if restored and self._requirements_ok(\n                engine, repair_tool, restored[2]\n            ):\n                self._remember_environment(engine, repair_tool, restored[1])\n                print(\n                    f"⚠️ {repair_tool} 安全更新失败，但原有 {engine} 环境仍可用；"\n                    "本次继续使用原环境。"\n                )\n                return True\n\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
     "repair fallback",
 )
 venv_path.write_text(venv, encoding="utf-8")
-
-ci_path = Path(".github/workflows/ci.yml")
-ci = ci_path.read_text(encoding="utf-8")
-anchor = '''                  assert auto.ensure_env('pdf2zh')\n                  assert auto.curr_envtool == 'conda'\n                  print('Environment manager semantics OK')\n'''
-replacement = '''                  assert auto.ensure_env('pdf2zh')\n                  assert auto.curr_envtool == 'conda'\n\n                  # A failed optional repair/update must fall back to the same\n                  # old environment when that runtime remains healthy.\n                  fallback = VirtualEnvManager('missing.json', names, 'conda', skip_install=True)\n                  fallback.skip_install = False\n                  old_conda = ('conda', Path('/tmp/old-conda'), Path(sys.executable))\n                  fallback._existing = lambda engine, tool: old_conda\n                  checks = iter([False, True])\n                  fallback._requirements_ok = lambda *args: next(checks)\n                  fallback.install_packages = lambda *args, **kwargs: False\n                  assert fallback.ensure_env('pdf2zh_next')\n                  assert fallback.curr_envtool == 'conda'\n\n                  # Windows-specific interpreter/PATH semantics are covered by\n                  # .github/workflows/windows-env-ci.yml on windows-latest.\n                  windows_ci = Path('.github/workflows/windows-env-ci.yml').read_text(encoding='utf-8')\n                  assert 'conda_python = conda_dir / \'python.exe\'' in windows_ci\n                  assert "runs-on: windows-latest" in windows_ci\n                  print('Environment manager semantics OK')\n'''
-ci = replace_once(ci, anchor, replacement, "CI environment semantics")
-ci_path.write_text(ci, encoding="utf-8")
-
 print("Windows conda update-fallback hotfix applied")

--- a/.github/scripts/apply_windows_conda_hotfix.py
+++ b/.github/scripts/apply_windows_conda_hotfix.py
@@ -1,22 +1,24 @@
+import re
 from pathlib import Path
 
-
-def replace_once(text: str, old: str, new: str, label: str) -> str:
-    if old not in text:
-        raise RuntimeError(f"missing patch anchor: {label}")
-    return text.replace(old, new, 1)
-
-
-# Windows Conda interpreter/PATH layout is already fixed on the review branch.
-# This patch adds the second invariant: a failed optional update must not disable
-# the old environment when that runtime is still healthy.
 venv_path = Path("server/utils/venv.py")
 venv = venv_path.read_text(encoding="utf-8")
-venv = replace_once(
-    venv,
-    '''            if self.install_packages(engine, repair_tool):\n                return True\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
-    '''            if self.install_packages(engine, repair_tool):\n                return True\n\n            # Updating/repairing is a maintenance action. If the transactional\n            # attempt fails, re-discover the original environment and keep using\n            # it whenever it is still healthy. A failed update must not turn a\n            # previously working runtime into a translation outage.\n            restored = self._existing(engine, repair_tool)\n            if restored and self._requirements_ok(\n                engine, repair_tool, restored[2]\n            ):\n                self._remember_environment(engine, repair_tool, restored[1])\n                print(\n                    f"⚠️ {repair_tool} 安全更新失败，但原有 {engine} 环境仍可用；"\n                    "本次继续使用原环境。"\n                )\n                return True\n\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
-    "repair fallback",
-)
-venv_path.write_text(venv, encoding="utf-8")
+
+if "安全更新失败，但原有" in venv:
+    print("Fallback already present")
+else:
+    pattern = re.compile(
+        r'''(?P<indent>\s{12})if self\.install_packages\(engine, repair_tool\):\s*\n'''
+        r'''(?P=indent)    return True\s*\n'''
+        r'''(?P=indent)print\("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。"\)\s*\n'''
+        r'''(?P=indent)return False'''
+    )
+    match = pattern.search(venv)
+    if not match:
+        raise RuntimeError("could not locate repair-failure block in ensure_env")
+    indent = match.group("indent")
+    replacement = f'''{indent}if self.install_packages(engine, repair_tool):\n{indent}    return True\n\n{indent}# Updating/repairing is a maintenance action. If the transactional\n{indent}# attempt fails, re-discover the original environment and keep using\n{indent}# it whenever it is still healthy. A failed update must not turn a\n{indent}# previously working runtime into a translation outage.\n{indent}restored = self._existing(engine, repair_tool)\n{indent}if restored and self._requirements_ok(\n{indent}    engine, repair_tool, restored[2]\n{indent}):\n{indent}    self._remember_environment(engine, repair_tool, restored[1])\n{indent}    print(\n{indent}        f"⚠️ {{repair_tool}} 安全更新失败，但原有 {{engine}} 环境仍可用；"\n{indent}        "本次继续使用原环境。"\n{indent}    )\n{indent}    return True\n\n{indent}print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n{indent}return False'''
+    venv = venv[: match.start()] + replacement + venv[match.end() :]
+    venv_path.write_text(venv, encoding="utf-8")
+
 print("Windows conda update-fallback hotfix applied")

--- a/.github/scripts/apply_windows_conda_hotfix.py
+++ b/.github/scripts/apply_windows_conda_hotfix.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    if old not in text:
+        raise RuntimeError(f"missing patch anchor: {label}")
+    return text.replace(old, new, 1)
+
+
+lifecycle_path = Path("server/utils/environment_lifecycle.py")
+lifecycle = lifecycle_path.read_text(encoding="utf-8")
+
+lifecycle = replace_once(
+    lifecycle,
+    '''def _python_in_env_dir(env_dir: Path) -> Path:\n    if platform.system() == "Windows":\n        return env_dir / "Scripts" / "python.exe"\n    return env_dir / "bin" / "python"\n''',
+    '''def _python_in_env_dir(env_dir: Path, env_tool: str = "uv") -> Path:\n    """Return the interpreter path for a managed environment.\n\n    Windows virtualenv/uv environments place Python under ``Scripts``, while\n    conda environments place ``python.exe`` at the environment root.  Keeping\n    this distinction here prevents a healthy historical conda environment from\n    being mistaken for a missing/broken environment.\n    """\n    if platform.system() == "Windows":\n        if env_tool == "conda":\n            return env_dir / "python.exe"\n        return env_dir / "Scripts" / "python.exe"\n    return env_dir / "bin" / "python"\n''',
+    "python path helper",
+)
+
+lifecycle = replace_once(
+    lifecycle,
+    '''        python_path = _python_in_env_dir(env_dir)\n        if python_path.exists():\n            return "uv", env_dir, python_path\n''',
+    '''        python_path = _python_in_env_dir(env_dir, "uv")\n        if python_path.exists():\n            return "uv", env_dir, python_path\n''',
+    "uv existing path",
+)
+
+lifecycle = replace_once(
+    lifecycle,
+    '''            python_path = _python_in_env_dir(env_dir)\n            if python_path.exists():\n                return "conda", env_dir, python_path\n''',
+    '''            python_path = _python_in_env_dir(env_dir, "conda")\n            if python_path.exists():\n                return "conda", env_dir, python_path\n''',
+    "conda existing path",
+)
+
+lifecycle = replace_once(
+    lifecycle,
+    '''    python_path = _python_in_env_dir(path)\n    if not python_path.exists():\n        raise RuntimeError(f"uv 环境没有生成 Python 可执行文件: {path}")\n''',
+    '''    python_path = _python_in_env_dir(path, "uv")\n    if not python_path.exists():\n        raise RuntimeError(f"uv 环境没有生成 Python 可执行文件: {path}")\n''',
+    "uv staging path",
+)
+
+lifecycle = replace_once(
+    lifecycle,
+    '''    python_path = _python_in_env_dir(staging_dir)\n    if not python_path.exists():\n        raise RuntimeError("staging conda 环境没有 Python 可执行文件")\n''',
+    '''    python_path = _python_in_env_dir(staging_dir, "conda")\n    if not python_path.exists():\n        raise RuntimeError(\n            f"staging conda 环境没有 Python 可执行文件: {python_path}"\n        )\n''',
+    "conda staging path",
+)
+
+lifecycle = replace_once(
+    lifecycle,
+    '''        final_python = _python_in_env_dir(final_dir)\n        if not validate_environment(\n''',
+    '''        final_python = _python_in_env_dir(final_dir, "conda")\n        if not validate_environment(\n''',
+    "conda activated path",
+)
+
+lifecycle_path.write_text(lifecycle, encoding="utf-8")
+
+venv_path = Path("server/utils/venv.py")
+venv = venv_path.read_text(encoding="utf-8")
+venv = replace_once(
+    venv,
+    '''            if self.install_packages(engine, repair_tool):\n                return True\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
+    '''            if self.install_packages(engine, repair_tool):\n                return True\n\n            # A maintenance/update failure must never invalidate a previously\n            # usable environment.  Re-discover it after the transactional\n            # attempt and continue with it when the old runtime is still healthy.\n            restored = self._existing(engine, repair_tool)\n            if restored and self._requirements_ok(\n                engine, repair_tool, restored[2]\n            ):\n                self._remember_environment(engine, repair_tool, restored[1])\n                print(\n                    f"⚠️ {repair_tool} 安全更新失败，但原有 {engine} 环境仍可用；"\n                    "本次继续使用原环境。"\n                )\n                return True\n\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
+    "repair fallback",
+)
+venv_path.write_text(venv, encoding="utf-8")
+
+ci_path = Path(".github/workflows/ci.yml")
+ci = ci_path.read_text(encoding="utf-8")
+anchor = '''                  assert auto.ensure_env('pdf2zh')\n                  assert auto.curr_envtool == 'conda'\n                  print('Environment manager semantics OK')\n'''
+replacement = '''                  assert auto.ensure_env('pdf2zh')\n                  assert auto.curr_envtool == 'conda'\n\n                  # Windows conda keeps python.exe at the environment root; uv\n                  # and virtualenv-style environments keep it under Scripts/.\n                  from utils import environment_lifecycle as lifecycle\n                  win_env = Path('C:/Users/test/miniconda3/envs/zotero-pdf2zh-next-venv')\n                  with patch.object(lifecycle.platform, 'system', return_value='Windows'):\n                      assert lifecycle._python_in_env_dir(win_env, 'conda') == win_env / 'python.exe'\n                      assert lifecycle._python_in_env_dir(win_env, 'uv') == win_env / 'Scripts' / 'python.exe'\n\n                  lifecycle_source = Path('server/utils/environment_lifecycle.py').read_text(encoding='utf-8')\n                  assert '_python_in_env_dir(env_dir, "conda")' in lifecycle_source\n                  assert '_python_in_env_dir(staging_dir, "conda")' in lifecycle_source\n                  assert '_python_in_env_dir(final_dir, "conda")' in lifecycle_source\n\n                  # If a transactional repair fails but the original runtime is\n                  # still healthy, translation must continue on that runtime.\n                  fallback = VirtualEnvManager('missing.json', names, 'conda', skip_install=True)\n                  fallback.skip_install = False\n                  old_conda = ('conda', Path('/tmp/old-conda'), Path(sys.executable))\n                  fallback._existing = lambda engine, tool: old_conda\n                  checks = iter([False, True])\n                  fallback._requirements_ok = lambda *args: next(checks)\n                  fallback.install_packages = lambda *args, **kwargs: False\n                  assert fallback.ensure_env('pdf2zh_next')\n                  assert fallback.curr_envtool == 'conda'\n                  print('Environment manager semantics OK')\n'''
+ci = replace_once(ci, anchor, replacement, "CI environment semantics")
+ci_path.write_text(ci, encoding="utf-8")
+
+print("Windows conda v4.1.0 hotfix applied")

--- a/.github/scripts/apply_windows_conda_hotfix.py
+++ b/.github/scripts/apply_windows_conda_hotfix.py
@@ -7,59 +7,15 @@ def replace_once(text: str, old: str, new: str, label: str) -> str:
     return text.replace(old, new, 1)
 
 
-lifecycle_path = Path("server/utils/environment_lifecycle.py")
-lifecycle = lifecycle_path.read_text(encoding="utf-8")
-
-lifecycle = replace_once(
-    lifecycle,
-    '''def _python_in_env_dir(env_dir: Path) -> Path:\n    if platform.system() == "Windows":\n        return env_dir / "Scripts" / "python.exe"\n    return env_dir / "bin" / "python"\n''',
-    '''def _python_in_env_dir(env_dir: Path, env_tool: str = "uv") -> Path:\n    """Return the interpreter path for a managed environment.\n\n    Windows virtualenv/uv environments place Python under ``Scripts``, while\n    conda environments place ``python.exe`` at the environment root.  Keeping\n    this distinction here prevents a healthy historical conda environment from\n    being mistaken for a missing/broken environment.\n    """\n    if platform.system() == "Windows":\n        if env_tool == "conda":\n            return env_dir / "python.exe"\n        return env_dir / "Scripts" / "python.exe"\n    return env_dir / "bin" / "python"\n''',
-    "python path helper",
-)
-
-lifecycle = replace_once(
-    lifecycle,
-    '''        python_path = _python_in_env_dir(env_dir)\n        if python_path.exists():\n            return "uv", env_dir, python_path\n''',
-    '''        python_path = _python_in_env_dir(env_dir, "uv")\n        if python_path.exists():\n            return "uv", env_dir, python_path\n''',
-    "uv existing path",
-)
-
-lifecycle = replace_once(
-    lifecycle,
-    '''            python_path = _python_in_env_dir(env_dir)\n            if python_path.exists():\n                return "conda", env_dir, python_path\n''',
-    '''            python_path = _python_in_env_dir(env_dir, "conda")\n            if python_path.exists():\n                return "conda", env_dir, python_path\n''',
-    "conda existing path",
-)
-
-lifecycle = replace_once(
-    lifecycle,
-    '''    python_path = _python_in_env_dir(path)\n    if not python_path.exists():\n        raise RuntimeError(f"uv 环境没有生成 Python 可执行文件: {path}")\n''',
-    '''    python_path = _python_in_env_dir(path, "uv")\n    if not python_path.exists():\n        raise RuntimeError(f"uv 环境没有生成 Python 可执行文件: {path}")\n''',
-    "uv staging path",
-)
-
-lifecycle = replace_once(
-    lifecycle,
-    '''    python_path = _python_in_env_dir(staging_dir)\n    if not python_path.exists():\n        raise RuntimeError("staging conda 环境没有 Python 可执行文件")\n''',
-    '''    python_path = _python_in_env_dir(staging_dir, "conda")\n    if not python_path.exists():\n        raise RuntimeError(\n            f"staging conda 环境没有 Python 可执行文件: {python_path}"\n        )\n''',
-    "conda staging path",
-)
-
-lifecycle = replace_once(
-    lifecycle,
-    '''        final_python = _python_in_env_dir(final_dir)\n        if not validate_environment(\n''',
-    '''        final_python = _python_in_env_dir(final_dir, "conda")\n        if not validate_environment(\n''',
-    "conda activated path",
-)
-
-lifecycle_path.write_text(lifecycle, encoding="utf-8")
-
+# The Windows Conda interpreter/PATH layout is already fixed on the review
+# branch.  This migration adds the second safety invariant: a failed optional
+# repair/update must not disable the old environment when it is still healthy.
 venv_path = Path("server/utils/venv.py")
 venv = venv_path.read_text(encoding="utf-8")
 venv = replace_once(
     venv,
     '''            if self.install_packages(engine, repair_tool):\n                return True\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
-    '''            if self.install_packages(engine, repair_tool):\n                return True\n\n            # A maintenance/update failure must never invalidate a previously\n            # usable environment.  Re-discover it after the transactional\n            # attempt and continue with it when the old runtime is still healthy.\n            restored = self._existing(engine, repair_tool)\n            if restored and self._requirements_ok(\n                engine, repair_tool, restored[2]\n            ):\n                self._remember_environment(engine, repair_tool, restored[1])\n                print(\n                    f"⚠️ {repair_tool} 安全更新失败，但原有 {engine} 环境仍可用；"\n                    "本次继续使用原环境。"\n                )\n                return True\n\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
+    '''            if self.install_packages(engine, repair_tool):\n                return True\n\n            # Updating/repairing is a maintenance action.  If the transactional\n            # attempt fails, re-discover the original environment and keep using\n            # it whenever it is still healthy.  A failed update must not turn a\n            # previously working runtime into a translation outage.\n            restored = self._existing(engine, repair_tool)\n            if restored and self._requirements_ok(\n                engine, repair_tool, restored[2]\n            ):\n                self._remember_environment(engine, repair_tool, restored[1])\n                print(\n                    f"⚠️ {repair_tool} 安全更新失败，但原有 {engine} 环境仍可用；"\n                    "本次继续使用原环境。"\n                )\n                return True\n\n            print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")\n            return False\n''',
     "repair fallback",
 )
 venv_path.write_text(venv, encoding="utf-8")
@@ -67,8 +23,8 @@ venv_path.write_text(venv, encoding="utf-8")
 ci_path = Path(".github/workflows/ci.yml")
 ci = ci_path.read_text(encoding="utf-8")
 anchor = '''                  assert auto.ensure_env('pdf2zh')\n                  assert auto.curr_envtool == 'conda'\n                  print('Environment manager semantics OK')\n'''
-replacement = '''                  assert auto.ensure_env('pdf2zh')\n                  assert auto.curr_envtool == 'conda'\n\n                  # Windows conda keeps python.exe at the environment root; uv\n                  # and virtualenv-style environments keep it under Scripts/.\n                  from utils import environment_lifecycle as lifecycle\n                  win_env = Path('C:/Users/test/miniconda3/envs/zotero-pdf2zh-next-venv')\n                  with patch.object(lifecycle.platform, 'system', return_value='Windows'):\n                      assert lifecycle._python_in_env_dir(win_env, 'conda') == win_env / 'python.exe'\n                      assert lifecycle._python_in_env_dir(win_env, 'uv') == win_env / 'Scripts' / 'python.exe'\n\n                  lifecycle_source = Path('server/utils/environment_lifecycle.py').read_text(encoding='utf-8')\n                  assert '_python_in_env_dir(env_dir, "conda")' in lifecycle_source\n                  assert '_python_in_env_dir(staging_dir, "conda")' in lifecycle_source\n                  assert '_python_in_env_dir(final_dir, "conda")' in lifecycle_source\n\n                  # If a transactional repair fails but the original runtime is\n                  # still healthy, translation must continue on that runtime.\n                  fallback = VirtualEnvManager('missing.json', names, 'conda', skip_install=True)\n                  fallback.skip_install = False\n                  old_conda = ('conda', Path('/tmp/old-conda'), Path(sys.executable))\n                  fallback._existing = lambda engine, tool: old_conda\n                  checks = iter([False, True])\n                  fallback._requirements_ok = lambda *args: next(checks)\n                  fallback.install_packages = lambda *args, **kwargs: False\n                  assert fallback.ensure_env('pdf2zh_next')\n                  assert fallback.curr_envtool == 'conda'\n                  print('Environment manager semantics OK')\n'''
+replacement = '''                  assert auto.ensure_env('pdf2zh')\n                  assert auto.curr_envtool == 'conda'\n\n                  # A failed optional repair/update must fall back to the same\n                  # old environment when that runtime remains healthy.\n                  fallback = VirtualEnvManager('missing.json', names, 'conda', skip_install=True)\n                  fallback.skip_install = False\n                  old_conda = ('conda', Path('/tmp/old-conda'), Path(sys.executable))\n                  fallback._existing = lambda engine, tool: old_conda\n                  checks = iter([False, True])\n                  fallback._requirements_ok = lambda *args: next(checks)\n                  fallback.install_packages = lambda *args, **kwargs: False\n                  assert fallback.ensure_env('pdf2zh_next')\n                  assert fallback.curr_envtool == 'conda'\n\n                  # Windows-specific interpreter/PATH semantics are covered by\n                  # .github/workflows/windows-env-ci.yml on windows-latest.\n                  windows_ci = Path('.github/workflows/windows-env-ci.yml').read_text(encoding='utf-8')\n                  assert 'conda_python = conda_dir / \'python.exe\'' in windows_ci\n                  assert "runs-on: windows-latest" in windows_ci\n                  print('Environment manager semantics OK')\n'''
 ci = replace_once(ci, anchor, replacement, "CI environment semantics")
 ci_path.write_text(ci, encoding="utf-8")
 
-print("Windows conda v4.1.0 hotfix applied")
+print("Windows conda update-fallback hotfix applied")

--- a/.github/workflows/apply-windows-conda-hotfix.yml
+++ b/.github/workflows/apply-windows-conda-hotfix.yml
@@ -1,0 +1,52 @@
+name: Apply Windows conda hotfix
+
+on:
+  push:
+    branches:
+      - agent/fix-windows-conda-v4.1.0
+
+permissions:
+  contents: write
+
+jobs:
+  apply:
+    if: ${{ !contains(github.event.head_commit.message, '[windows-conda-hotfix-applied]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: agent/fix-windows-conda-v4.1.0
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Apply patch
+        run: python .github/scripts/apply_windows_conda_hotfix.py
+
+      - name: Validate patch
+        env:
+          PYTHONPATH: server
+        run: |
+          python -m compileall -q server
+          python - <<'PY'
+          from pathlib import Path
+          from unittest.mock import patch
+          from utils import environment_lifecycle as lifecycle
+
+          root = Path('C:/Users/test/miniconda3/envs/zotero-pdf2zh-next-venv')
+          with patch.object(lifecycle.platform, 'system', return_value='Windows'):
+              assert lifecycle._python_in_env_dir(root, 'conda') == root / 'python.exe'
+              assert lifecycle._python_in_env_dir(root, 'uv') == root / 'Scripts' / 'python.exe'
+          print('Windows conda interpreter layout OK')
+          PY
+          git diff --check
+
+      - name: Commit business changes
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add server/utils/environment_lifecycle.py server/utils/venv.py .github/workflows/ci.yml
+          git commit -m 'fix: restore Windows conda environment compatibility [windows-conda-hotfix-applied]'
+          git push origin HEAD:agent/fix-windows-conda-v4.1.0

--- a/.github/workflows/apply-windows-conda-hotfix.yml
+++ b/.github/workflows/apply-windows-conda-hotfix.yml
@@ -31,11 +31,14 @@ jobs:
         run: |
           python -m compileall -q server
           python - <<'PY'
+          import sys
           import tempfile
           from pathlib import Path
           from unittest.mock import patch
           from utils import environment_lifecycle as lifecycle
+          from utils.venv import VirtualEnvManager
 
+          # Windows Conda layout: python.exe lives at env root.
           with tempfile.TemporaryDirectory() as temp:
               root = Path(temp)
               conda_dir = root / 'conda-env'
@@ -44,14 +47,31 @@ jobs:
               conda_python.touch()
               with patch.object(lifecycle.platform, 'system', return_value='Windows'):
                   assert lifecycle.resolve_environment_python(conda_dir) == conda_python
-          print('Windows conda interpreter layout OK')
+
+          # Failed optional repair/update: rediscover the old environment and
+          # continue when it is still healthy.
+          names = {
+              'pdf2zh': 'zotero-pdf2zh-venv',
+              'pdf2zh_next': 'zotero-pdf2zh-next-venv',
+          }
+          manager = VirtualEnvManager('missing.json', names, 'conda', skip_install=True)
+          manager.skip_install = False
+          old_conda = ('conda', Path('/tmp/old-conda'), Path(sys.executable))
+          manager._existing = lambda engine, tool: old_conda
+          checks = iter([False, True])
+          manager._requirements_ok = lambda *args: next(checks)
+          manager.install_packages = lambda *args, **kwargs: False
+          assert manager.ensure_env('pdf2zh_next')
+          assert manager.curr_envtool == 'conda'
+          assert manager.curr_env_path == str(old_conda[1])
+          print('Windows conda layout and failed-update fallback OK')
           PY
           git diff --check
 
-      - name: Commit business changes
+      - name: Commit business change
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add server/utils/venv.py .github/workflows/ci.yml
+          git add server/utils/venv.py
           git commit -m 'fix: keep healthy environment after failed update [windows-conda-hotfix-applied]'
           git push origin HEAD:agent/fix-windows-conda-v4.1.0

--- a/.github/workflows/apply-windows-conda-hotfix.yml
+++ b/.github/workflows/apply-windows-conda-hotfix.yml
@@ -1,16 +1,16 @@
 name: Apply Windows conda hotfix
 
 on:
-  push:
+  pull_request:
     branches:
-      - agent/fix-windows-conda-v4.1.0
+      - agent/deepseek-thinking-controls
 
 permissions:
   contents: write
 
 jobs:
   apply:
-    if: ${{ !contains(github.event.head_commit.message, '[windows-conda-hotfix-applied]') }}
+    if: ${{ github.event.pull_request.head.ref == 'agent/fix-windows-conda-v4.1.0' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,14 +31,19 @@ jobs:
         run: |
           python -m compileall -q server
           python - <<'PY'
+          import tempfile
           from pathlib import Path
           from unittest.mock import patch
           from utils import environment_lifecycle as lifecycle
 
-          root = Path('C:/Users/test/miniconda3/envs/zotero-pdf2zh-next-venv')
-          with patch.object(lifecycle.platform, 'system', return_value='Windows'):
-              assert lifecycle._python_in_env_dir(root, 'conda') == root / 'python.exe'
-              assert lifecycle._python_in_env_dir(root, 'uv') == root / 'Scripts' / 'python.exe'
+          with tempfile.TemporaryDirectory() as temp:
+              root = Path(temp)
+              conda_dir = root / 'conda-env'
+              (conda_dir / 'conda-meta').mkdir(parents=True)
+              conda_python = conda_dir / 'python.exe'
+              conda_python.touch()
+              with patch.object(lifecycle.platform, 'system', return_value='Windows'):
+                  assert lifecycle.resolve_environment_python(conda_dir) == conda_python
           print('Windows conda interpreter layout OK')
           PY
           git diff --check
@@ -47,6 +52,6 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add server/utils/environment_lifecycle.py server/utils/venv.py .github/workflows/ci.yml
-          git commit -m 'fix: restore Windows conda environment compatibility [windows-conda-hotfix-applied]'
+          git add server/utils/venv.py .github/workflows/ci.yml
+          git commit -m 'fix: keep healthy environment after failed update [windows-conda-hotfix-applied]'
           git push origin HEAD:agent/fix-windows-conda-v4.1.0

--- a/server/utils/venv.py
+++ b/server/utils/venv.py
@@ -291,6 +291,22 @@ class VirtualEnvManager:
             print(f"🔧 检测到 {repair_tool} 环境不完整，将通过 staging 安全修复。")
             if self.install_packages(engine, repair_tool):
                 return True
+
+            # Updating/repairing is a maintenance action. If the transactional
+            # attempt fails, re-discover the original environment and keep using
+            # it whenever it is still healthy. A failed update must not turn a
+            # previously working runtime into a translation outage.
+            restored = self._existing(engine, repair_tool)
+            if restored and self._requirements_ok(
+                engine, repair_tool, restored[2]
+            ):
+                self._remember_environment(engine, repair_tool, restored[1])
+                print(
+                    f"⚠️ {repair_tool} 安全更新失败，但原有 {engine} 环境仍可用；"
+                    "本次继续使用原环境。"
+                )
+                return True
+
             print("⚠️ 安全修复失败；不会自动切换到另一个环境管理工具。")
             return False
 


### PR DESCRIPTION
Temporary validation only. Root cause confirmed: Windows Conda keeps python.exe at the environment root, not Scripts/python.exe. The review branch already received the Windows layout/PATH fix as 93e2003e546a271d38788806c4a785e3e393f281 and the failed-update fallback as 426c3677cb0f2944723bdd8f54ac397c3facb6c6. Windows Environment CI and normal CI both passed on the validated hotfix tree. The temporary apply workflow reported failure only because its final no-op commit step found nothing left to commit; its validation step had already passed. Closed without merge.