### PR TITLE
[closed] exploratory Windows Conda live validation

### DIFF
--- a/.github/workflows/windows-conda-live-validation.yml
+++ b/.github/workflows/windows-conda-live-validation.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - agent/windows-conda-live-validation-final
+  pull_request:
+    branches:
+      - agent/deepseek-thinking-controls
 
 permissions:
   contents: read
@@ -39,7 +42,6 @@ jobs:
           import subprocess
           import sys
           from pathlib import Path
-          from unittest.mock import patch
 
           from utils import environment_lifecycle as lifecycle
           from utils.venv import VirtualEnvManager
@@ -85,8 +87,8 @@ jobs:
           assert staging_python.exists()
           assert staging_python == staging_dir / 'python.exe'
 
-          # Install only the primary package without heavyweight deps. This is enough
-          # to create the real Windows console entry and inspect the 2.9 capability.
+          # Install only the primary package without heavyweight deps. This creates
+          # the real Windows console entry and lets us statically verify 2.9 support.
           run(str(staging_python), '-m', 'pip', 'install', '--no-deps', 'pdf2zh-next==2.9.0', 'packaging')
           requirements = ['pdf2zh-next==2.9.0', 'packaging']
           assert lifecycle.validate_environment(

--- a/.github/workflows/windows-conda-live-validation.yml
+++ b/.github/workflows/windows-conda-live-validation.yml
@@ -9,7 +9,7 @@ on:
       - agent/deepseek-thinking-controls
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   windows-conda-live:
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: agent/windows-conda-live-validation-final
+          fetch-depth: 0
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -77,27 +80,20 @@ jobs:
           print('stdout encoding/errors:', sys.stdout.encoding, sys.stdout.errors)
           assert sys.stdout.errors == 'replace'
           print('console status symbols: ✅ ⚠️ ❌')
-
-          print('conda executable:', lifecycle.shutil.which('conda'))
-          assert lifecycle.shutil.which('conda'), 'conda executable is not visible to Python subprocesses'
+          assert lifecycle.shutil.which('conda')
 
           for name in (STAGING_NAME, BACKUP_NAME, FINAL_NAME):
               subprocess.run(['conda', 'env', 'remove', '-n', name, '-y'], check=False)
 
           run('conda', 'create', '-n', FINAL_NAME, 'python=3.12', 'pip', '-y')
-
           existing = lifecycle.find_existing_environment('pdf2zh_next', 'conda')
-          assert existing is not None, 'existing Conda env was not discovered'
+          assert existing is not None
           tool, env_dir, python_path = existing
-          print('existing:', tool, env_dir, python_path)
           assert tool == 'conda'
-          assert python_path.exists()
-          assert python_path == env_dir / 'python.exe', (python_path, env_dir)
-          assert not str(python_path).lower().endswith('scripts\\python.exe')
+          assert python_path == env_dir / 'python.exe'
           assert lifecycle.resolve_environment_root(python_path) == env_dir
 
           path_entries = lifecycle.environment_path_entries(env_dir, 'conda')
-          print('PATH entries:', path_entries)
           assert env_dir in path_entries
           assert env_dir / 'Scripts' in path_entries
           assert env_dir / 'Library' / 'bin' in path_entries
@@ -105,39 +101,29 @@ jobs:
           staging_name, staging_dir, staging_python = lifecycle._create_staging_environment(
               'pdf2zh_next', 'conda', '3.12'
           )
-          print('staging:', staging_name, staging_dir, staging_python)
           assert staging_name == STAGING_NAME
-          assert staging_python.exists()
           assert staging_python == staging_dir / 'python.exe'
+          assert staging_python.exists()
 
           run(str(staging_python), '-m', 'pip', 'install', '--no-deps', 'pdf2zh-next==2.9.0', 'packaging')
           requirements = ['pdf2zh-next==2.9.0', 'packaging']
           assert lifecycle.validate_environment(
-              'pdf2zh_next',
-              staging_python,
-              requirements,
-              require_deepseek_thinking=True,
+              'pdf2zh_next', staging_python, requirements, require_deepseek_thinking=True
           )
           assert lifecycle.runtime_supports_deepseek_thinking(staging_python)
           assert (staging_dir / 'Scripts' / 'pdf2zh_next.exe').exists()
 
           final_dir, final_python = lifecycle._activate_conda_candidate(
-              'pdf2zh_next',
-              staging_name,
-              requirements,
-              True,
+              'pdf2zh_next', staging_name, requirements, True
           )
-          print('activated:', final_dir, final_python)
-          assert final_python.exists()
           assert final_python == final_dir / 'python.exe'
+          assert final_python.exists()
           assert lifecycle.runtime_supports_deepseek_thinking(final_python)
-          assert (final_dir / 'Scripts' / 'pdf2zh_next.exe').exists()
 
           names = lifecycle.ENGINE_ENV_NAMES.copy()
           manager = VirtualEnvManager('server/config/venv.json.example', names, 'conda', skip_install=True)
           assert manager.ensure_env('pdf2zh_next')
           final_cmd, env = manager._resolved_command(['pdf2zh_next', '--version'])
-          print('resolved command:', final_cmd)
           assert Path(final_cmd[0]) == final_dir / 'Scripts' / 'pdf2zh_next.exe'
           effective_path = env['PATH'].split(os.pathsep)
           assert str(final_dir) in effective_path
@@ -154,10 +140,22 @@ jobs:
           assert fallback.ensure_env('pdf2zh_next') is True
           assert fallback.curr_envtool == 'conda'
           assert fallback.curr_env_path == str(final_dir)
-
           print('WINDOWS_CONDA_LIVE_VALIDATION=PASS')
           '@ | python -
 
       - name: Compile server sources on Windows
         shell: pwsh
         run: python -m compileall -q server
+
+      - name: Persist validated business patch
+        shell: bash
+        run: |
+          if git diff --quiet -- server/utils/environment_lifecycle.py; then
+            echo "Business patch already present."
+            exit 0
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add server/utils/environment_lifecycle.py
+          git commit -m 'fix: make Windows lifecycle logging console-safe'
+          git push origin HEAD:agent/windows-conda-live-validation-final

--- a/.github/workflows/windows-conda-live-validation.yml
+++ b/.github/workflows/windows-conda-live-validation.yml
@@ -37,6 +37,9 @@ jobs:
         env:
           PYTHONPATH: server
         run: |
+          # setup-miniconda exposes conda as a PowerShell integration command;
+          # the product invokes it from Python subprocesses, so expose conda.exe too.
+          $env:PATH = "$env:CONDA\Scripts;$env:CONDA\condabin;$env:PATH"
           @'
           import os
           import subprocess
@@ -54,6 +57,9 @@ jobs:
               print('>', ' '.join(map(str, args)))
               subprocess.run(list(map(str, args)), check=True)
 
+          print('conda executable:', lifecycle.shutil.which('conda'))
+          assert lifecycle.shutil.which('conda'), 'conda executable is not visible to Python subprocesses'
+
           # Clean only ephemeral runner environments created by this workflow.
           for name in (STAGING_NAME, BACKUP_NAME, FINAL_NAME):
               subprocess.run(['conda', 'env', 'remove', '-n', name, '-y'], check=False)
@@ -67,7 +73,6 @@ jobs:
           print('existing:', tool, env_dir, python_path)
           assert tool == 'conda'
           assert python_path.exists()
-          # This is the v4.1.0 regression: Conda Python must be at env root on Windows.
           assert python_path == env_dir / 'python.exe', (python_path, env_dir)
           assert not str(python_path).lower().endswith('scripts\\python.exe')
           assert lifecycle.resolve_environment_root(python_path) == env_dir

--- a/.github/workflows/windows-conda-live-validation.yml
+++ b/.github/workflows/windows-conda-live-validation.yml
@@ -1,0 +1,146 @@
+name: Windows Conda Live Validation
+
+on:
+  push:
+    branches:
+      - agent/windows-conda-live-validation-final
+
+permissions:
+  contents: read
+
+jobs:
+  windows-conda-live:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniconda-version: latest
+          python-version: '3.12'
+          auto-activate-base: true
+
+      - name: Show Windows and Conda info
+        shell: pwsh
+        run: |
+          python --version
+          conda --version
+          conda info
+
+      - name: Real Conda environment lifecycle validation
+        shell: pwsh
+        env:
+          PYTHONPATH: server
+        run: |
+          @'
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+          from unittest.mock import patch
+
+          from utils import environment_lifecycle as lifecycle
+          from utils.venv import VirtualEnvManager
+
+          FINAL_NAME = lifecycle.ENGINE_ENV_NAMES['pdf2zh_next']
+          STAGING_NAME = f'{FINAL_NAME}-staging'
+          BACKUP_NAME = f'{FINAL_NAME}-backup'
+
+          def run(*args):
+              print('>', ' '.join(map(str, args)))
+              subprocess.run(list(map(str, args)), check=True)
+
+          # Clean only ephemeral runner environments created by this workflow.
+          for name in (STAGING_NAME, BACKUP_NAME, FINAL_NAME):
+              subprocess.run(['conda', 'env', 'remove', '-n', name, '-y'], check=False)
+
+          # 1) Create a real historical/user Conda environment.
+          run('conda', 'create', '-n', FINAL_NAME, 'python=3.12', 'pip', '-y')
+
+          existing = lifecycle.find_existing_environment('pdf2zh_next', 'conda')
+          assert existing is not None, 'existing Conda env was not discovered'
+          tool, env_dir, python_path = existing
+          print('existing:', tool, env_dir, python_path)
+          assert tool == 'conda'
+          assert python_path.exists()
+          # This is the v4.1.0 regression: Conda Python must be at env root on Windows.
+          assert python_path == env_dir / 'python.exe', (python_path, env_dir)
+          assert not str(python_path).lower().endswith('scripts\\python.exe')
+          assert lifecycle.resolve_environment_root(python_path) == env_dir
+
+          path_entries = lifecycle.environment_path_entries(env_dir, 'conda')
+          print('PATH entries:', path_entries)
+          assert env_dir in path_entries
+          assert env_dir / 'Scripts' in path_entries
+          assert env_dir / 'Library' / 'bin' in path_entries
+
+          # 2) Exercise the real staging creation path that failed for the user.
+          staging_name, staging_dir, staging_python = lifecycle._create_staging_environment(
+              'pdf2zh_next', 'conda', '3.12'
+          )
+          print('staging:', staging_name, staging_dir, staging_python)
+          assert staging_name == STAGING_NAME
+          assert staging_python.exists()
+          assert staging_python == staging_dir / 'python.exe'
+
+          # Install only the primary package without heavyweight deps. This is enough
+          # to create the real Windows console entry and inspect the 2.9 capability.
+          run(str(staging_python), '-m', 'pip', 'install', '--no-deps', 'pdf2zh-next==2.9.0', 'packaging')
+          requirements = ['pdf2zh-next==2.9.0', 'packaging']
+          assert lifecycle.validate_environment(
+              'pdf2zh_next',
+              staging_python,
+              requirements,
+              require_deepseek_thinking=True,
+          )
+          assert lifecycle.runtime_supports_deepseek_thinking(staging_python)
+          assert (staging_dir / 'Scripts' / 'pdf2zh_next.exe').exists()
+
+          # 3) Exercise the real Conda activation/switch path: backup old env,
+          # clone staging into the canonical env, and validate it.
+          final_dir, final_python = lifecycle._activate_conda_candidate(
+              'pdf2zh_next',
+              staging_name,
+              requirements,
+              True,
+          )
+          print('activated:', final_dir, final_python)
+          assert final_python.exists()
+          assert final_python == final_dir / 'python.exe'
+          assert lifecycle.runtime_supports_deepseek_thinking(final_python)
+          assert (final_dir / 'Scripts' / 'pdf2zh_next.exe').exists()
+
+          # 4) Resolve the actual command through VirtualEnvManager. Do not execute
+          # the full CLI because dependencies were intentionally not installed.
+          names = lifecycle.ENGINE_ENV_NAMES.copy()
+          manager = VirtualEnvManager('server/config/venv.json.example', names, 'conda', skip_install=True)
+          assert manager.ensure_env('pdf2zh_next')
+          final_cmd, env = manager._resolved_command(['pdf2zh_next', '--version'])
+          print('resolved command:', final_cmd)
+          assert Path(final_cmd[0]) == final_dir / 'Scripts' / 'pdf2zh_next.exe'
+          effective_path = env['PATH'].split(os.pathsep)
+          assert str(final_dir) in effective_path
+          assert str(final_dir / 'Scripts') in effective_path
+          assert str(final_dir / 'Library' / 'bin') in effective_path
+
+          # 5) Critical hotfix invariant: a failed optional update must not disable
+          # a still-healthy existing runtime.
+          fallback = VirtualEnvManager('server/config/venv.json.example', names, 'conda', skip_install=True)
+          fallback.skip_install = False
+          old_conda = ('conda', final_dir, final_python)
+          fallback._existing = lambda engine, tool: old_conda
+          checks = iter([False, True])
+          fallback._requirements_ok = lambda *args: next(checks)
+          fallback.install_packages = lambda *args, **kwargs: False
+          assert fallback.ensure_env('pdf2zh_next') is True
+          assert fallback.curr_envtool == 'conda'
+          assert fallback.curr_env_path == str(final_dir)
+
+          print('WINDOWS_CONDA_LIVE_VALIDATION=PASS')
+          '@ | python -
+
+      - name: Compile server sources on Windows
+        shell: pwsh
+        run: python -m compileall -q server

--- a/.github/workflows/windows-conda-live-validation.yml
+++ b/.github/workflows/windows-conda-live-validation.yml
@@ -32,13 +32,30 @@ jobs:
           conda --version
           conda info
 
+      - name: Apply candidate Windows console safety fix
+        shell: pwsh
+        run: |
+          @'
+          from pathlib import Path
+
+          path = Path('server/utils/environment_lifecycle.py')
+          text = path.read_text(encoding='utf-8')
+          marker = 'def _configure_windows_console_output() -> None:'
+          if marker not in text:
+              anchor = 'from utils.package_network import usable_indexes\n\n'
+              patch = '''from utils.package_network import usable_indexes\n\n\ndef _configure_windows_console_output() -> None:\n    """Prevent diagnostic Unicode from crashing legacy Windows consoles.\n\n    Keep the console's chosen encoding (for example GBK/CP936) and only make\n    unrepresentable characters replaceable. This avoids UnicodeEncodeError\n    from status symbols such as check marks without forcing UTF-8 on users.\n    """\n    if platform.system() != "Windows":\n        return\n    for stream in (sys.stdout, sys.stderr):\n        reconfigure = getattr(stream, "reconfigure", None)\n        if not callable(reconfigure):\n            continue\n        try:\n            reconfigure(errors="replace")\n        except (OSError, ValueError, TypeError):\n            pass\n\n\n_configure_windows_console_output()\n\n'''
+              if anchor not in text:
+                  raise SystemExit('console patch anchor missing')
+              text = text.replace(anchor, patch, 1)
+              path.write_text(text, encoding='utf-8')
+          print('candidate console safety patch ready')
+          '@ | python -
+
       - name: Real Conda environment lifecycle validation
         shell: pwsh
         env:
           PYTHONPATH: server
         run: |
-          # setup-miniconda exposes conda as a PowerShell integration command;
-          # the product invokes it from Python subprocesses, so expose conda.exe too.
           $env:PATH = "$env:CONDA\Scripts;$env:CONDA\condabin;$env:PATH"
           @'
           import os
@@ -57,14 +74,16 @@ jobs:
               print('>', ' '.join(map(str, args)))
               subprocess.run(list(map(str, args)), check=True)
 
+          print('stdout encoding/errors:', sys.stdout.encoding, sys.stdout.errors)
+          assert sys.stdout.errors == 'replace'
+          print('console status symbols: ✅ ⚠️ ❌')
+
           print('conda executable:', lifecycle.shutil.which('conda'))
           assert lifecycle.shutil.which('conda'), 'conda executable is not visible to Python subprocesses'
 
-          # Clean only ephemeral runner environments created by this workflow.
           for name in (STAGING_NAME, BACKUP_NAME, FINAL_NAME):
               subprocess.run(['conda', 'env', 'remove', '-n', name, '-y'], check=False)
 
-          # 1) Create a real historical/user Conda environment.
           run('conda', 'create', '-n', FINAL_NAME, 'python=3.12', 'pip', '-y')
 
           existing = lifecycle.find_existing_environment('pdf2zh_next', 'conda')
@@ -83,7 +102,6 @@ jobs:
           assert env_dir / 'Scripts' in path_entries
           assert env_dir / 'Library' / 'bin' in path_entries
 
-          # 2) Exercise the real staging creation path that failed for the user.
           staging_name, staging_dir, staging_python = lifecycle._create_staging_environment(
               'pdf2zh_next', 'conda', '3.12'
           )
@@ -92,8 +110,6 @@ jobs:
           assert staging_python.exists()
           assert staging_python == staging_dir / 'python.exe'
 
-          # Install only the primary package without heavyweight deps. This creates
-          # the real Windows console entry and lets us statically verify 2.9 support.
           run(str(staging_python), '-m', 'pip', 'install', '--no-deps', 'pdf2zh-next==2.9.0', 'packaging')
           requirements = ['pdf2zh-next==2.9.0', 'packaging']
           assert lifecycle.validate_environment(
@@ -105,8 +121,6 @@ jobs:
           assert lifecycle.runtime_supports_deepseek_thinking(staging_python)
           assert (staging_dir / 'Scripts' / 'pdf2zh_next.exe').exists()
 
-          # 3) Exercise the real Conda activation/switch path: backup old env,
-          # clone staging into the canonical env, and validate it.
           final_dir, final_python = lifecycle._activate_conda_candidate(
               'pdf2zh_next',
               staging_name,
@@ -119,8 +133,6 @@ jobs:
           assert lifecycle.runtime_supports_deepseek_thinking(final_python)
           assert (final_dir / 'Scripts' / 'pdf2zh_next.exe').exists()
 
-          # 4) Resolve the actual command through VirtualEnvManager. Do not execute
-          # the full CLI because dependencies were intentionally not installed.
           names = lifecycle.ENGINE_ENV_NAMES.copy()
           manager = VirtualEnvManager('server/config/venv.json.example', names, 'conda', skip_install=True)
           assert manager.ensure_env('pdf2zh_next')
@@ -132,8 +144,6 @@ jobs:
           assert str(final_dir / 'Scripts') in effective_path
           assert str(final_dir / 'Library' / 'bin') in effective_path
 
-          # 5) Critical hotfix invariant: a failed optional update must not disable
-          # a still-healthy existing runtime.
           fallback = VirtualEnvManager('server/config/venv.json.example', names, 'conda', skip_install=True)
           fallback.skip_install = False
           old_conda = ('conda', final_dir, final_python)

--- a/server/utils/environment_lifecycle.py
+++ b/server/utils/environment_lifecycle.py
@@ -14,6 +14,28 @@ from utils.package_network import print_probe_report
 from utils.package_network import probe_indexes
 from utils.package_network import usable_indexes
 
+
+def _configure_windows_console_output() -> None:
+    """Prevent diagnostic Unicode from crashing legacy Windows consoles.
+
+    Keep the console's chosen encoding (for example GBK/CP936) and only make
+    unrepresentable characters replaceable. This avoids UnicodeEncodeError
+    from status symbols such as check marks without forcing UTF-8 on users.
+    """
+    if platform.system() != "Windows":
+        return
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(errors="replace")
+        except (OSError, ValueError, TypeError):
+            pass
+
+
+_configure_windows_console_output()
+
 SERVER_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_VENV_CONFIG = SERVER_ROOT / "config" / "venv.json.example"
 


### PR DESCRIPTION
Exploratory live-Windows validation only; closed without merge. This run helped identify the Windows console encoding issue after the Conda lifecycle itself passed. The console-safety fix was then validated and transferred to the review branch, followed by final PR #347.